### PR TITLE
修复要素创建索引的笔误

### DIFF
--- a/src/geo/featureIndex.js
+++ b/src/geo/featureIndex.js
@@ -2,7 +2,7 @@ import rbush from 'rbush';
 import turfBox from '@turf/bbox';
 export default class FeatureIndex {
   constructor(data) {
-    this.tree = rbush();
+    this.tree = new rbush();
     this.rawData = data;
     data.features.forEach(feature => {
       this.insert(feature);


### PR DESCRIPTION
在src/geo/featureIndex.js文件中，使用rbush创建要素时，导入的rbush应该使用new 关键字