### PR TITLE
feat: mapbox添加fitBoundsOptions

### DIFF
--- a/packages/core/src/services/config/ConfigService.ts
+++ b/packages/core/src/services/config/ConfigService.ts
@@ -17,6 +17,9 @@ const defaultSceneConfig: Partial<ISceneConfig & IRenderConfig> = {
   logoVisible: true,
   antialias: true,
   preserveDrawingBuffer: false,
+  fitBoundsOptions: {
+    animate: false,
+  },
 };
 
 /**

--- a/packages/core/src/services/config/IConfigService.ts
+++ b/packages/core/src/services/config/IConfigService.ts
@@ -8,6 +8,7 @@ export interface ISceneConfig extends IRenderConfig {
   map: IMapWrapper;
   logoPosition?: PositionName;
   logoVisible?: boolean;
+  fitBoundsOptions?: mapboxgl.FitBoundsOptions;
 }
 
 // interface IValidateResult {

--- a/packages/core/src/services/config/IConfigService.ts
+++ b/packages/core/src/services/config/IConfigService.ts
@@ -9,7 +9,7 @@ export interface ISceneConfig extends IRenderConfig {
   logoPosition?: PositionName;
   logoVisible?: boolean;
   animate?: boolean;
-  fitBoundsOptions?: mapboxgl.FitBoundsOptions;
+  fitBoundsOptions?: unknown;
 }
 
 // interface IValidateResult {

--- a/packages/core/src/services/config/IConfigService.ts
+++ b/packages/core/src/services/config/IConfigService.ts
@@ -8,6 +8,7 @@ export interface ISceneConfig extends IRenderConfig {
   map: IMapWrapper;
   logoPosition?: PositionName;
   logoVisible?: boolean;
+  animate?: boolean;
   fitBoundsOptions?: mapboxgl.FitBoundsOptions;
 }
 

--- a/packages/core/src/services/layer/ILayerService.ts
+++ b/packages/core/src/services/layer/ILayerService.ts
@@ -155,7 +155,7 @@ export interface ILayer {
   destroy(): void;
   source(data: any, option?: ISourceCFG): ILayer;
   setData(data: any, option?: ISourceCFG): ILayer;
-  fitBounds(): ILayer;
+  fitBounds(fitBoundsOptions?: mapboxgl.FitBoundsOptions): ILayer;
   /**
    * 向当前图层注册插件
    * @param plugin 插件实例
@@ -222,6 +222,7 @@ export interface ILayerConfig {
   visible: boolean;
   zIndex: number;
   autoFit: boolean;
+  fitBoundsOptions?: mapboxgl.FitBoundsOptions;
   name: string; //
   blend: keyof typeof BlendType;
   pickedFeatureID: number;

--- a/packages/core/src/services/layer/ILayerService.ts
+++ b/packages/core/src/services/layer/ILayerService.ts
@@ -155,7 +155,7 @@ export interface ILayer {
   destroy(): void;
   source(data: any, option?: ISourceCFG): ILayer;
   setData(data: any, option?: ISourceCFG): ILayer;
-  fitBounds(fitBoundsOptions?: mapboxgl.FitBoundsOptions): ILayer;
+  fitBounds(fitBoundsOptions?: unknown): ILayer;
   /**
    * 向当前图层注册插件
    * @param plugin 插件实例
@@ -222,7 +222,7 @@ export interface ILayerConfig {
   visible: boolean;
   zIndex: number;
   autoFit: boolean;
-  fitBoundsOptions?: mapboxgl.FitBoundsOptions;
+  fitBoundsOptions?: unknown;
   name: string; //
   blend: keyof typeof BlendType;
   pickedFeatureID: number;

--- a/packages/core/src/services/map/IMapService.ts
+++ b/packages/core/src/services/map/IMapService.ts
@@ -50,7 +50,7 @@ export interface IMapService<RawMap = {}> {
   zoomOut(): void;
   panTo(p: Point): void;
   panBy(pixel: Point): void;
-  fitBounds(bound: Bounds): void;
+  fitBounds(bound: Bounds, fitBoundsOptions?: mapboxgl.FitBoundsOptions): void;
   setZoomAndCenter(zoom: number, center: Point): void;
   setCenter(center: [number, number]): void;
   setPitch(pitch: number): void;

--- a/packages/core/src/services/map/IMapService.ts
+++ b/packages/core/src/services/map/IMapService.ts
@@ -50,7 +50,7 @@ export interface IMapService<RawMap = {}> {
   zoomOut(): void;
   panTo(p: Point): void;
   panBy(pixel: Point): void;
-  fitBounds(bound: Bounds, fitBoundsOptions?: mapboxgl.FitBoundsOptions): void;
+  fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void;
   setZoomAndCenter(zoom: number, center: Point): void;
   setCenter(center: [number, number]): void;
   setPitch(pitch: number): void;

--- a/packages/core/src/services/map/IMapService.ts
+++ b/packages/core/src/services/map/IMapService.ts
@@ -11,6 +11,15 @@ export interface IPoint {
   y: number;
 }
 
+export interface IStatusOptions {
+  showIndoorMap: boolean;
+  resizeEnable: boolean;
+  dragEnable: boolean;
+  keyboardEnable: boolean;
+  doubleClickZoom: boolean;
+  zoomEnable: boolean;
+  rotateEnable: boolean;
+}
 export type MapStyle = string | { [key: string]: any };
 export interface IMapWrapper {
   setContainer(container: Container, id: string | HTMLDivElement): void;
@@ -56,6 +65,7 @@ export interface IMapService<RawMap = {}> {
   setPitch(pitch: number): void;
   setZoom(zoom: number): void;
   setMapStyle(style: any): void;
+  setStatus(option: Partial<IStatusOptions>): void;
 
   // coordinates methods
   pixelToLngLat(pixel: Point): ILngLat;

--- a/packages/layers/src/core/BaseLayer.ts
+++ b/packages/layers/src/core/BaseLayer.ts
@@ -654,7 +654,7 @@ export default class BaseLayer<ChildLayerStyleOptions = {}> extends EventEmitter
   /**
    * zoom to layer Bounds
    */
-  public fitBounds(): ILayer {
+  public fitBounds(fitBoundsOptions?: mapboxgl.FitBoundsOptions): ILayer {
     if (!this.inited) {
       this.updateLayerConfig({
         autoFit: true,
@@ -663,10 +663,13 @@ export default class BaseLayer<ChildLayerStyleOptions = {}> extends EventEmitter
     }
     const source = this.getSource();
     const extent = source.extent;
-    this.mapService.fitBounds([
-      [extent[0], extent[1]],
-      [extent[2], extent[3]],
-    ]);
+    this.mapService.fitBounds(
+      [
+        [extent[0], extent[1]],
+        [extent[2], extent[3]],
+      ],
+      fitBoundsOptions,
+    );
     return this;
   }
 
@@ -876,9 +879,9 @@ export default class BaseLayer<ChildLayerStyleOptions = {}> extends EventEmitter
 
   private sourceEvent = () => {
     this.dataState.dataSourceNeedUpdate = true;
-    const { autoFit } = this.getLayerConfig();
+    const { autoFit, fitBoundsOptions } = this.getLayerConfig();
     if (autoFit) {
-      this.fitBounds();
+      this.fitBounds(fitBoundsOptions);
     }
 
     this.emit('dataUpdate');

--- a/packages/layers/src/core/BaseLayer.ts
+++ b/packages/layers/src/core/BaseLayer.ts
@@ -654,7 +654,7 @@ export default class BaseLayer<ChildLayerStyleOptions = {}> extends EventEmitter
   /**
    * zoom to layer Bounds
    */
-  public fitBounds(fitBoundsOptions?: mapboxgl.FitBoundsOptions): ILayer {
+  public fitBounds(fitBoundsOptions?: unknown): ILayer {
     if (!this.inited) {
       this.updateLayerConfig({
         autoFit: true,

--- a/packages/layers/src/plugins/LayerStylePlugin.ts
+++ b/packages/layers/src/plugins/LayerStylePlugin.ts
@@ -11,10 +11,10 @@ export default class LayerStylePlugin implements ILayerPlugin {
     layer.hooks.afterInit.tap('LayerStylePlugin', () => {
       // 更新图层默认状态
       layer.updateLayerConfig({});
-      const { autoFit } = layer.getLayerConfig();
+      const { autoFit, fitBoundsOptions } = layer.getLayerConfig();
       if (autoFit) {
         setTimeout(() => {
-          layer.fitBounds();
+          layer.fitBounds(fitBoundsOptions);
         }, 100);
       }
     });

--- a/packages/maps/src/amap/map.ts
+++ b/packages/maps/src/amap/map.ts
@@ -11,6 +11,7 @@ import {
   IMapConfig,
   IMapService,
   IPoint,
+  IStatusOptions,
   IViewport,
   MapServiceEvent,
   MapStyle,
@@ -200,6 +201,10 @@ export default class AMapService
   }
   public setMapStyle(style: string): void {
     this.map.setMapStyle(this.getMapStyle(style));
+  }
+
+  public setStatus(option: Partial<IStatusOptions>) {
+    this.map.setStatus(option);
   }
   public pixelToLngLat(pixel: [number, number]): ILngLat {
     const lngLat = this.map.pixelToLngLat(new AMap.Pixel(pixel[0], pixel[1]));

--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -157,8 +157,11 @@ export default class MapboxService
     this.panTo(pixel);
   }
 
-  public fitBounds(bound: Bounds): void {
-    this.map.fitBounds(bound);
+  public fitBounds(
+    bound: Bounds,
+    fitBoundsOptions?: mapboxgl.FitBoundsOptions,
+  ): void {
+    this.map.fitBounds(bound, fitBoundsOptions);
   }
 
   public setMaxZoom(max: number): void {

--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -157,11 +157,8 @@ export default class MapboxService
     this.panTo(pixel);
   }
 
-  public fitBounds(
-    bound: Bounds,
-    fitBoundsOptions?: mapboxgl.FitBoundsOptions,
-  ): void {
-    this.map.fitBounds(bound, fitBoundsOptions);
+  public fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void {
+    this.map.fitBounds(bound, fitBoundsOptions as mapboxgl.FitBoundsOptions);
   }
 
   public setMaxZoom(max: number): void {

--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -11,6 +11,7 @@ import {
   IMapConfig,
   IMapService,
   IPoint,
+  IStatusOptions,
   IViewport,
   MapServiceEvent,
   MapStyle,
@@ -167,6 +168,38 @@ export default class MapboxService
 
   public setMinZoom(min: number): void {
     this.map.setMinZoom(min);
+  }
+  public setStatus(option: Partial<IStatusOptions>) {
+    if (option.doubleClickZoom === true) {
+      this.map.doubleClickZoom.enable();
+    }
+    if (option.doubleClickZoom === false) {
+      this.map.doubleClickZoom.disable();
+    }
+    if (option.dragEnable === false) {
+      this.map.dragPan.disable();
+    }
+    if (option.dragEnable === true) {
+      this.map.dragPan.enable();
+    }
+    if (option.rotateEnable === false) {
+      this.map.dragRotate.disable();
+    }
+    if (option.dragEnable === true) {
+      this.map.dragRotate.enable();
+    }
+    if (option.keyboardEnable === false) {
+      this.map.keyboard.disable();
+    }
+    if (option.keyboardEnable === true) {
+      this.map.keyboard.enable();
+    }
+    if (option.zoomEnable === false) {
+      this.map.scrollZoom.disable();
+    }
+    if (option.zoomEnable === true) {
+      this.map.scrollZoom.enable();
+    }
   }
 
   public setZoomAndCenter(zoom: number, center: [number, number]): void {

--- a/packages/react/src/component/LayerAttribute/Layer.tsx
+++ b/packages/react/src/component/LayerAttribute/Layer.tsx
@@ -113,12 +113,6 @@ export default function BaseLayer(type: string, props: ILayerProps) {
     }
   }, [options?.blend]);
 
-  // useEffect(() => {
-  //   if (layer && layer.inited && options && options.autoFit === true) {
-  //     layer.fitBounds();
-  //   }
-  // }, [options?.autoFit]);
-
   return layer !== null && layer !== undefined ? (
     <LayerContext.Provider value={layer}>
       <Source layer={layer} source={source} />

--- a/packages/react/src/component/LayerAttribute/Source.tsx
+++ b/packages/react/src/component/LayerAttribute/Source.tsx
@@ -18,7 +18,7 @@ export default React.memo(function Chart(props: ISourceProps) {
       layer.setData(data, sourceOption);
     }
     if (sourceOption.autoFit) {
-      layer.fitBounds();
+      layer.fitBounds(sourceOption && sourceOption.fitBoundsOptions);
     }
   }, [data, JSON.stringify(sourceOption)]);
   return null;

--- a/packages/react/src/component/LayerAttribute/index.ts
+++ b/packages/react/src/component/LayerAttribute/index.ts
@@ -60,6 +60,8 @@ export interface ISourceOptions extends ISourceCFG {
   data: any;
   // 每次更新数据之后是否自适应缩放
   autoFit?: boolean;
+  // Mapbox 自适应的参数
+  fitBoundsOptions?: any;
 }
 
 export interface IActiveOptions {

--- a/packages/scene/src/IMapController.ts
+++ b/packages/scene/src/IMapController.ts
@@ -49,7 +49,7 @@ export default interface IMapController {
   /**
    * 调整地图适合指定区域
    */
-  fitBounds(bound: Bounds, fitBoundsOptions?: mapboxgl.FitBoundsOptions): void;
+  fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void;
 
   setRotation(rotation: number): void;
 

--- a/packages/scene/src/IMapController.ts
+++ b/packages/scene/src/IMapController.ts
@@ -49,7 +49,7 @@ export default interface IMapController {
   /**
    * 调整地图适合指定区域
    */
-  fitBounds(bound: Bounds): void;
+  fitBounds(bound: Bounds, fitBoundsOptions?: mapboxgl.FitBoundsOptions): void;
 
   setRotation(rotation: number): void;
 

--- a/packages/scene/src/IMapController.ts
+++ b/packages/scene/src/IMapController.ts
@@ -1,4 +1,4 @@
-import { Bounds, ILngLat, IPoint, Point } from '@antv/l7-core';
+import { Bounds, ILngLat, IPoint, IStatusOptions, Point } from '@antv/l7-core';
 
 export default interface IMapController {
   /**
@@ -51,17 +51,28 @@ export default interface IMapController {
    */
   fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void;
 
+  getContainer(): HTMLElement | null;
+  getSize(): [number, number];
+  // get map status method
+  getMinZoom(): number;
+  getMaxZoom(): number;
+  // get map params
+  getType(): string;
+  getMapContainer(): HTMLElement | null;
+
+  // control with raw map
   setRotation(rotation: number): void;
-
   setZoomAndCenter(zoom: number, center: Point): void;
+  setCenter(center: [number, number]): void;
+  setPitch(pitch: number): void;
+  setZoom(zoom: number): void;
+  setMapStyle(style: any): void;
+  setStatus(option: Partial<IStatusOptions>): void;
 
-  setMapStyle(style: string): void;
-
+  // coordinates methods
   pixelToLngLat(pixel: Point): ILngLat;
-
   lngLatToPixel(lnglat: Point): IPoint;
-
   containerToLngLat(pixel: Point): ILngLat;
-
   lngLatToContainer(lnglat: Point): IPoint;
+  exportMap(type: 'jpg' | 'png'): string;
 }

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -58,6 +58,7 @@ class Scene
   private popupService: IPopupService;
   private fontService: IFontService;
   private interactionService: IInteractionService;
+  private animate: boolean;
   private fitBoundsOptions: mapboxgl.FitBoundsOptions;
   private container: Container;
 
@@ -67,7 +68,8 @@ class Scene
       map,
       logoPosition,
       logoVisible = true,
-      fitBoundsOptions = { animate: true },
+      animate = true,
+      fitBoundsOptions = {},
     } = config;
     this.fitBoundsOptions = fitBoundsOptions;
     // 创建场景容器
@@ -281,7 +283,11 @@ class Scene
     bound: Bounds,
     fitBoundsOptions?: mapboxgl.FitBoundsOptions,
   ): void {
-    this.mapService.fitBounds(bound, this.fitBoundsOptions || fitBoundsOptions);
+    this.mapService.fitBounds(
+      bound,
+      // 选项优先级：用户传入，覆盖animate直接配置，覆盖Scene配置项传入
+      fitBoundsOptions || { ...this.fitBoundsOptions, animate: this.animate },
+    );
   }
 
   public setZoomAndCenter(zoom: number, center: Point): void {

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -59,7 +59,7 @@ class Scene
   private fontService: IFontService;
   private interactionService: IInteractionService;
   private animate: boolean;
-  private fitBoundsOptions: mapboxgl.FitBoundsOptions;
+  private fitBoundsOptions: unknown;
   private container: Container;
 
   public constructor(config: ISceneConfig) {
@@ -279,14 +279,14 @@ class Scene
   public setZoom(zoom: number): void {
     this.mapService.setZoom(zoom);
   }
-  public fitBounds(
-    bound: Bounds,
-    fitBoundsOptions?: mapboxgl.FitBoundsOptions,
-  ): void {
+  public fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void {
     this.mapService.fitBounds(
       bound,
       // 选项优先级：用户传入，覆盖animate直接配置，覆盖Scene配置项传入
-      fitBoundsOptions || { ...this.fitBoundsOptions, animate: this.animate },
+      fitBoundsOptions || {
+        ...(this.fitBoundsOptions as object),
+        animate: this.animate,
+      },
     );
   }
 

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -270,8 +270,11 @@ class Scene
   public setZoom(zoom: number): void {
     this.mapService.setZoom(zoom);
   }
-  public fitBounds(bound: Bounds): void {
-    this.mapService.fitBounds(bound);
+  public fitBounds(
+    bound: Bounds,
+    fitBoundsOptions?: mapboxgl.FitBoundsOptions,
+  ): void {
+    this.mapService.fitBounds(bound, fitBoundsOptions);
   }
 
   public setZoomAndCenter(zoom: number, center: Point): void {

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -24,6 +24,7 @@ import {
   IRendererService,
   ISceneConfig,
   ISceneService,
+  IStatusOptions,
   Point,
   SceneEventList,
   TYPES,
@@ -58,20 +59,10 @@ class Scene
   private popupService: IPopupService;
   private fontService: IFontService;
   private interactionService: IInteractionService;
-  private animate: boolean;
-  private fitBoundsOptions: unknown;
   private container: Container;
 
   public constructor(config: ISceneConfig) {
-    const {
-      id,
-      map,
-      logoPosition,
-      logoVisible = true,
-      animate = true,
-      fitBoundsOptions = {},
-    } = config;
-    this.fitBoundsOptions = fitBoundsOptions;
+    const { id, map } = config;
     // 创建场景容器
     const sceneContainer = createSceneContainer();
     this.container = sceneContainer;
@@ -111,6 +102,21 @@ class Scene
     // TODO: 初始化组件
 
     this.initControl();
+  }
+  public getSize(): [number, number] {
+    return this.mapService.getSize();
+  }
+  public getMinZoom(): number {
+    return this.mapService.getMinZoom();
+  }
+  public getMaxZoom(): number {
+    return this.mapService.getMaxZoom();
+  }
+  public getType(): string {
+    return this.mapService.getType();
+  }
+  public getMapContainer(): HTMLElement | null {
+    return this.mapService.getMapContainer();
   }
 
   public getMapService(): IMapService<unknown> {
@@ -279,13 +285,14 @@ class Scene
   public setZoom(zoom: number): void {
     this.mapService.setZoom(zoom);
   }
-  public fitBounds(bound: Bounds, fitBoundsOptions?: unknown): void {
+  public fitBounds(bound: Bounds, options?: unknown): void {
+    const { fitBoundsOptions, animate } = this.sceneService.getSceneConfig();
     this.mapService.fitBounds(
       bound,
       // 选项优先级：用户传入，覆盖animate直接配置，覆盖Scene配置项传入
-      fitBoundsOptions || {
-        ...(this.fitBoundsOptions as object),
-        animate: this.animate,
+      options || {
+        ...(fitBoundsOptions as object),
+        animate,
       },
     );
   }
@@ -296,6 +303,10 @@ class Scene
 
   public setMapStyle(style: any): void {
     this.mapService.setMapStyle(style);
+  }
+
+  public setStatus(options: IStatusOptions) {
+    this.mapService.setStatus(options);
   }
 
   // conversion Method

--- a/packages/scene/src/index.ts
+++ b/packages/scene/src/index.ts
@@ -58,11 +58,18 @@ class Scene
   private popupService: IPopupService;
   private fontService: IFontService;
   private interactionService: IInteractionService;
-
+  private fitBoundsOptions: mapboxgl.FitBoundsOptions;
   private container: Container;
 
   public constructor(config: ISceneConfig) {
-    const { id, map, logoPosition, logoVisible = true } = config;
+    const {
+      id,
+      map,
+      logoPosition,
+      logoVisible = true,
+      fitBoundsOptions = { animate: true },
+    } = config;
+    this.fitBoundsOptions = fitBoundsOptions;
     // 创建场景容器
     const sceneContainer = createSceneContainer();
     this.container = sceneContainer;
@@ -274,7 +281,7 @@ class Scene
     bound: Bounds,
     fitBoundsOptions?: mapboxgl.FitBoundsOptions,
   ): void {
-    this.mapService.fitBounds(bound, fitBoundsOptions);
+    this.mapService.fitBounds(bound, this.fitBoundsOptions || fitBoundsOptions);
   }
 
   public setZoomAndCenter(zoom: number, center: Point): void {

--- a/stories/React/components/world_ncov_fill.tsx
+++ b/stories/React/components/world_ncov_fill.tsx
@@ -85,7 +85,7 @@ export default React.memo(function Map() {
           center: [110.19382669582967, 50.258134],
           pitch: 0,
           style: 'blank',
-          zoom: 1,
+          zoom: 10,
         }}
         style={{
           position: 'absolute',

--- a/stories/React/components/world_ncov_fill.tsx
+++ b/stories/React/components/world_ncov_fill.tsx
@@ -100,6 +100,10 @@ export default React.memo(function Map() {
             key={'1'}
             options={{
               autoFit: true,
+              fitBoundsOptions: {
+                duration: 0,
+                animate: false,
+              },
             }}
             source={{
               data,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

feat: mapbox添加fitBoundsOptions;

可在new Scene的时候传入；也可在Layer中传入，也可直接在fitBounds时传入。

支持Mapbox的fitBounds，不支持对AMap的调整。
