### PR TITLE
fix(layer): 用计算出的数据范围 * 2代替之前的视野范围

### DIFF
--- a/packages/core/src/services/source/ISourceService.ts
+++ b/packages/core/src/services/source/ISourceService.ts
@@ -62,10 +62,7 @@ export interface ISource {
   cluster: boolean;
   clusterOptions: Partial<IClusterOptions>;
   setData(data: any): void;
-  updateClusterData(
-    bbox: [[number, number], [number, number]],
-    zoom: number,
-  ): void;
+  updateClusterData(zoom: number): void;
   getFeatureById(id: number): unknown;
   getFeatureId(field: string, value: any): number | undefined;
   getClusters(zoom: number): any;

--- a/packages/layers/src/core/BaseLayer.ts
+++ b/packages/layers/src/core/BaseLayer.ts
@@ -746,9 +746,8 @@ export default class BaseLayer<ChildLayerStyleOptions = {}> extends EventEmitter
   public setSource(source: Source) {
     this.layerSource = source;
     const zoom = this.mapService.getZoom();
-    const viewBounds = this.mapService.getBounds();
     if (this.layerSource.cluster) {
-      this.layerSource.updateClusterData(viewBounds, zoom);
+      this.layerSource.updateClusterData(zoom);
     }
     // source 可能会复用，会在其它layer被修改
     this.layerSource.on('update', this.sourceEvent);

--- a/packages/layers/src/plugins/DataSourcePlugin.ts
+++ b/packages/layers/src/plugins/DataSourcePlugin.ts
@@ -27,9 +27,8 @@ export default class DataSourcePlugin implements ILayerPlugin {
     const cluster = source.cluster;
     const { zoom = 0, maxZoom = 16 } = source.clusterOptions;
     const newZoom = this.mapService.getZoom() - 1;
-    const viewBounds = this.mapService.getBounds();
     if (cluster && Math.abs(zoom - newZoom) > 1 && maxZoom > zoom) {
-      source.updateClusterData(viewBounds, Math.floor(newZoom));
+      source.updateClusterData(Math.floor(newZoom));
       return true;
     }
     return false;

--- a/packages/source/__tests__/source.spec.ts
+++ b/packages/source/__tests__/source.spec.ts
@@ -1,4 +1,3 @@
-import { bBoxToBounds } from '@antv/l7-utils';
 import Source from '../src/source';
 import Point from './data/point';
 import Polygon from './data/polygon';
@@ -21,6 +20,6 @@ describe('source constructor', () => {
         field: 'mag',
       },
     });
-    source.updateClusterData(bBoxToBounds(source.extent), 2);
+    source.updateClusterData(2);
   });
 });

--- a/packages/source/src/source.ts
+++ b/packages/source/src/source.ts
@@ -11,7 +11,7 @@ import {
   lazyInject,
   TYPES,
 } from '@antv/l7-core';
-import { bBoxToBounds, boundsContains, extent } from '@antv/l7-utils';
+import { bBoxToBounds, padBounds, extent } from '@antv/l7-utils';
 import {
   BBox,
   Feature,
@@ -85,16 +85,11 @@ export default class Source extends EventEmitter {
   public getClustersLeaves(id: number): any {
     return this.clusterIndex.getLeaves(id, Infinity);
   }
-  public updateClusterData(
-    bbox: [[number, number], [number, number]],
-    zoom: number,
-  ): void {
+  public updateClusterData(zoom: number): void {
     const { method = 'sum', field } = this.clusterOptions;
-    if (!boundsContains(bbox, bBoxToBounds(this.extent))) {
-      return;
-    }
+    const newBounds = padBounds(bBoxToBounds(this.extent),2);
     let data = this.clusterIndex.getClusters(
-      bbox[0].concat(bbox[1]),
+      newBounds[0].concat(newBounds[1]),
       Math.floor(zoom),
     );
     this.clusterOptions.zoom = zoom;


### PR DESCRIPTION
如果按照视野范围进行计算聚合数据会出现新的问题，比如当计算出的数据范围大于视野范围时，里面的判断会return，导致不聚合现象的产生。此次pr取消了上次pr的一部分，转而使用计算出的数据范围 * 2，可以避免此类现象的产生。

fix #511

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->
