### PR TITLE
fix: drillUpTrigglerEvent向上钻取的触发事件拼写错误

### DIFF
--- a/docs/api/district/drilldown.zh.md
+++ b/docs/api/district/drilldown.zh.md
@@ -36,7 +36,7 @@ DrillDownLayer 提供默认提供通过 Layer 的交互事件，实现上钻下�
 
 向下钻取的触发事件 ⛔customTrigger 为 true 时不生效
 
-### drillUpTriggleEvent
+### drillUpTrigglerEvent
 
 向上钻取的触发事件 ⛔customTrigger 为 true 时不生效
 


### PR DESCRIPTION
L7-boundary/src\layer\drillDown.ts 44行 也为drillUpTrigglerEvent
![image](https://user-images.githubusercontent.com/49489369/121674458-ac7a9100-cae4-11eb-8fb8-c6eee69cda42.png)
