### PR TITLE
feat: `PointLayer` support multi lines

### DIFF
--- a/packages/layers/src/point/models/text.ts
+++ b/packages/layers/src/point/models/text.ts
@@ -419,7 +419,7 @@ export default class TextModel extends BaseModel {
         // @ts-ignore
         size,
         textAnchor,
-        'center',
+        'left',
         spacing,
         textOffset,
         iconfont,

--- a/packages/layers/src/utils/symbol-layout.ts
+++ b/packages/layers/src/utils/symbol-layout.ts
@@ -174,7 +174,7 @@ function shapeLines(
     }
 
     x = 0;
-    y += lineHeight;
+    y -= lineHeight + 5;
   });
 
   const { horizontalAlign, verticalAlign } = getAnchorAlignment(textAnchor);
@@ -192,7 +192,7 @@ function shapeLines(
   const height = y - yOffset;
 
   shaping.top += -verticalAlign * height;
-  shaping.bottom = shaping.top + height;
+  shaping.bottom = shaping.top - height;
   shaping.left += -horizontalAlign * maxLineLength;
   shaping.right = shaping.left + maxLineLength;
 }
@@ -249,7 +249,7 @@ function shapeIconFont(
     }
 
     x = 0;
-    y += lineHeight;
+    y -= lineHeight + 5;
   });
 
   const { horizontalAlign, verticalAlign } = getAnchorAlignment(textAnchor);
@@ -267,7 +267,7 @@ function shapeIconFont(
   const height = y - yOffset;
 
   shaping.top += -verticalAlign * height;
-  shaping.bottom = shaping.top + height;
+  shaping.bottom = shaping.top - height;
   shaping.left += -horizontalAlign * maxLineLength;
   shaping.right = shaping.left + maxLineLength;
 }

--- a/stories/Layers/components/Text.tsx
+++ b/stories/Layers/components/Text.tsx
@@ -39,7 +39,7 @@ export default class TextLayerDemo extends React.Component {
           y: 'w',
         },
       })
-      .shape('s', 'text')
+      .shape(['s', 'm'], (...args) => args.map(i => `${i}\n`).join(''))
       // .shape('circle')
       .size(18)
       .filter('t', (t) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

#### Fix issue

- Close #693

##### Description of change
- 目前文本默认是居中的，但计算多行文本中每个文字的位置会有问题，所以改成 `left`
- 换行文本的 `y` 计算有误，应该是减去行高，之前导致文本渲染行的顺序是反的

<img width="499" alt="Screen Shot 2021-11-12 at 8 46 08 PM" src="https://user-images.githubusercontent.com/20318608/141469930-d5dbf45f-4b7d-425f-a0ab-3aad48332cd7.png">


#### TODO
- 目前文本 layer的 size 实际是配置行高，不是字体大小，可以加这个参数
-  文本对齐的配置也可以由用户配置，目前是 hard code 在代码里
- 文本对齐算法估计要重新弄一下