### PR TITLE
fix: type ILayerConfig already has animateOption

### DIFF
--- a/packages/layers/src/core/interface.ts
+++ b/packages/layers/src/core/interface.ts
@@ -72,8 +72,6 @@ export interface IPointLayerStyleOptions {
   unit?: string;
   mask?: boolean;
   maskInside?: boolean;
-
-  animateOption: IAnimateOption;
 }
 
 export interface IPolygonLayerStyleOptions {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

修复点图层 config 配置类型错误问题

```ts
error TS2345: Argument of type '{ name: string; colors?: string[] | undefined; size?: number | undefined; shape?: string | undefined; shape2d?: string[] | undefined; shape3d?: string[] | undefined; scales?: { [key: string]: IScale; } | undefined; ... 30 more ...; onClick?: ((pickedFeature: IPickedFeature) => void) | undefined; }' is not assignable to parameter of type 'Partial<ILayerConfig & IPointLayerStyleOptions>'.
Types of property 'animateOption' are incompatible.
Type 'Partial<IAnimateOption> | undefined' is not assignable to type '(Partial<IAnimateOption> & IAnimateOption) | undefined'.
```
