### PR TITLE
fix: 修复拾取状态残留导致的拾取高亮错误

### DIFF
--- a/packages/core/src/services/interaction/PickingService.ts
+++ b/packages/core/src/services/interaction/PickingService.ts
@@ -281,7 +281,7 @@ export default class PickingService implements IPickingService {
           // Tip: clear last picked layer state
           this.pickedLayers.map((pickedlayer) => {
             this.selectFeature(pickedlayer, new Uint8Array([0, 0, 0, 0]));
-          })
+          });
 
           const isPicked = this.pickFromPickingFBO(layer, target);
           this.layerService.pickedLayerId = isPicked ? +layer.id : -1;

--- a/packages/core/src/services/interaction/PickingService.ts
+++ b/packages/core/src/services/interaction/PickingService.ts
@@ -48,6 +48,9 @@ export default class PickingService implements IPickingService {
 
   private lastPickTime: number = new Date().getTime();
 
+  // Tip: 记录当前拾取中的 layers
+  private pickedLayers: ILayer[] = [];
+
   public init(id: string) {
     const {
       createTexture2D,
@@ -274,6 +277,12 @@ export default class PickingService implements IPickingService {
 
           layer.renderModels(true);
           layer.hooks.afterPickingEncode.call();
+
+          // Tip: clear last picked layer state
+          this.pickedLayers.map((pickedlayer) => {
+            this.selectFeature(pickedlayer, new Uint8Array([0, 0, 0, 0]));
+          })
+
           const isPicked = this.pickFromPickingFBO(layer, target);
           this.layerService.pickedLayerId = isPicked ? +layer.id : -1;
 
@@ -355,6 +364,7 @@ export default class PickingService implements IPickingService {
         // trigger onHover/Click callback on layer
         isPicked = true;
         layer.setCurrentPickId(pickedFeatureIdx);
+        this.pickedLayers = [layer];
         this.triggerHoverOnLayer(layer, layerTarget); // 触发拾取事件
       }
     } else {
@@ -377,6 +387,7 @@ export default class PickingService implements IPickingService {
       });
       this.triggerHoverOnLayer(layer, layerTarget);
       layer.setCurrentPickId(null);
+      this.pickedLayers = [];
     }
 
     if (enableHighlight) {

--- a/stories/Map/components/amap2demo_polygon.tsx
+++ b/stories/Map/components/amap2demo_polygon.tsx
@@ -13,7 +13,7 @@ export default class Amap2demo_polygon extends React.Component {
   public async componentDidMount() {
     const scene = new Scene({
       id: 'map',
-      map: new GaodeMapV2({
+      map: new GaodeMap({
         pitch: 40,
         center: [120, 30],
         zoom: 13,
@@ -44,33 +44,59 @@ export default class Amap2demo_polygon extends React.Component {
       ],
     };
 
+    const data2 = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {
+            testOpacity: 0.8,
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [113.8623046875 + 1, 30.031055426540206],
+                [116.3232421875 + 1, 30.031055426540206],
+                [116.3232421875 + 1, 31.090574094954192],
+                [113.8623046875 + 1, 31.090574094954192],
+                [113.8623046875 + 1, 30.031055426540206],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
     const layer = new PolygonLayer({
       autoFit: true,
     })
       .source(data)
       .shape('fill')
       .color('red')
+      .active(true)
       .style({
-        opacityLinear: {
-          enable: true,
-          dir: 'in',
-        },
+        // opacityLinear: {
+        //   enable: true,
+        //   dir: 'in',
+        // },
       });
     scene.addLayer(layer);
 
     const layer2 = new PolygonLayer({
       autoFit: true,
     })
-      .source(data)
+      .source(data2)
       .shape('fill')
-      .color('red')
+      .color('#ff0')
+      .active(true)
       .style({
-        opacity: 0.4,
+        // opacity: 0.4,
         // opacityLinear: {
         //   enable: true,
         //   dir: 'out',
         // },
-        raisingHeight: 50000,
+        // raisingHeight: 50000,
       });
     scene.addLayer(layer2);
   }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->
错误状态的触发：
1. 两个不同的图层存在重叠部分
2. 从后渲染的图层经过重叠部分移到先渲染的图层时触发
![屏幕录制2022-05-10 下午10 35 00 2022-05-10 22_36_40](https://user-images.githubusercontent.com/42212176/167656395-189c6b18-cc42-4a93-9909-f8e12de59dc1.gif)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] commit message follows commit guidelines

##### Description of change
1. 在 pickService 中新增 pickedLayers 记录被拾取选中的 layer
2. 每次在进行拾取操作的时候先进行清除选中状态的操作
```javascript
private async pickingLayers(target: IInteractionTarget) {
...
          // Tip: clear last picked layer state
          this.pickedLayers.map((pickedlayer) => {
            this.selectFeature(pickedlayer, new Uint8Array([0, 0, 0, 0]));
          });
...
}
```