### PR TITLE
fix: markerLayer在GaodeMapV2做底图时removeMarkerLayer视图图层层级改变时会复原被删除的图层

### DIFF
--- a/dev-demos/features/customLayer/marker-layer.md
+++ b/dev-demos/features/customLayer/marker-layer.md
@@ -2,14 +2,14 @@
 
 ```tsx
 import { Marker, MarkerLayer, Scene } from '@antv/l7';
-import { GaodeMap } from '@antv/l7-maps';
+import { GaodeMapV2 } from '@antv/l7-maps';
 import React, { useEffect } from 'react';
 
 export default () => {
   useEffect(() => {
     const scene = new Scene({
       id: 'map',
-      map: new GaodeMap({
+      map: new GaodeMapV2({
         center: [105, 30.258134],
         zoom: 3,
       }),
@@ -43,7 +43,9 @@ export default () => {
     )
       .then((res) => res.json())
       .then((nodes) => {
-        const markerLayer = new MarkerLayer();
+        const markerLayer = new MarkerLayer(
+          {cluster:true}
+        );
         for (let i = 0; i < 400; i++) {
           const { coordinates } = nodes.features[i].geometry;
           const el = document.createElement('label');

--- a/packages/component/src/marker-layer.ts
+++ b/packages/component/src/marker-layer.ts
@@ -159,16 +159,19 @@ export default class MarkerLayer extends EventEmitter {
     this.clusterMarkers.forEach((clusterMarker: IMarker) => {
       clusterMarker.remove();
     });
-    this.mapsService.off('camerachange', this.update);
-    this.mapsService.off('camerachange', this.setContainerSize.bind(this));
-    this.mapsService.off('viewchange', this.setContainerSize.bind(this));
     this.markers = [];
     this.points=[];
     this.clusterMarkers = [];
   }
-
+  public unRegisterMarkerLayerEvent(){
+    this.mapsService.off('camerachange', this.update);
+    this.mapsService.off('viewchange', this.update);
+    this.mapsService.off('camerachange', this.setContainerSize.bind(this));
+    this.mapsService.off('viewchange', this.setContainerSize.bind(this));
+  }
   public destroy() {
     this.clear();
+    this.unRegisterMarkerLayerEvent();
     this.removeAllListeners();
   }
 


### PR DESCRIPTION
fix: markerLayer在GaodeMapV2做底图时removeMarkerLayer视图图层层级改变时会复原被删除的图层及去除clear方法中调用注销监听事件