### PR TITLE
fix: 修复 LayerPopup 中的类型 BaseLayer => ILayer

### DIFF
--- a/packages/component/src/popup/layerPopup.ts
+++ b/packages/component/src/popup/layerPopup.ts
@@ -1,7 +1,4 @@
 import { ILayer, IPopupOption } from '@antv/l7-core';
-// @ts-ignore
-// tslint:disable-next-line:no-implicit-dependencies
-import { BaseLayer } from '@antv/l7-layers';
 import { DOM } from '@antv/l7-utils';
 import { Container } from 'inversify';
 import { get } from 'lodash';
@@ -16,7 +13,7 @@ export type LayerField = {
 };
 
 export type LayerPopupConfigItem = {
-  layer: BaseLayer | string;
+  layer: ILayer | string;
   fields: Array<LayerField | string>;
 };
 
@@ -26,10 +23,10 @@ export interface ILayerPopupOption extends IPopupOption {
 }
 
 type LayerMapInfo = {
-  onMouseMove?: (layer: BaseLayer, e: any) => void;
-  onMouseOut?: (layer: BaseLayer, e: any) => void;
-  onClick?: (layer: BaseLayer, e: any) => void;
-  onSourceUpdate?: (layer: BaseLayer) => void;
+  onMouseMove?: (layer: ILayer, e: any) => void;
+  onMouseOut?: (layer: ILayer, e: any) => void;
+  onClick?: (layer: ILayer, e: any) => void;
+  onSourceUpdate?: (layer: ILayer) => void;
 } & Partial<LayerPopupConfigItem>;
 
 export { LayerPopup };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] 将 LayerPopup 中使用 BaseLayer 作为通用图层类型改为使用 ILayer

