### PR TITLE
Add missing git repo info

### DIFF
--- a/packages/l7/package.json
+++ b/packages/l7/package.json
@@ -38,5 +38,6 @@
   "gitHead": "684ba4eb806a798713496d3fc0b4d1e17517dc31",
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "repository": "git@github.com:antvis/L7.git"
 }


### PR DESCRIPTION
![image](https://github.com/antvis/L7/assets/3455798/fec89682-0045-4a13-a19f-7e906bee2d98)