### PR TITLE
fix: 防止点击 Popup 关闭按钮时，误触发 Layer click 事件

### DIFF
--- a/dev-demos/component/popup/layerPopup.tsx
+++ b/dev-demos/component/popup/layerPopup.tsx
@@ -6,7 +6,7 @@ import {
   PolygonLayer,
   Scene,
 } from '@antv/l7';
-import { circle, featureCollection, point } from '@turf/turf';
+import { featureCollection, point } from '@turf/turf';
 import React, { useState } from 'react';
 // tslint:disable-next-line:no-duplicate-imports
 import { FunctionComponent, useEffect } from 'react';
@@ -50,33 +50,12 @@ const Demo: FunctionComponent = () => {
         .color('#ffffff')
         .shape('circle')
         .size(10);
-
       const polygonLayer = new PolygonLayer({
         name: 'polygonLayer',
       });
       polygonLayer
-        .source(
-          featureCollection([
-            circle([120.104697, 30.260704], 30, {
-              units: 'meters',
-              properties: {
-                name: '测试点1',
-                lng: 120.104697,
-                lat: 30.260704,
-                lines: [1, 2, 3, 4, 5, false, '2'],
-              },
-            }),
-            circle([120.104697, 30.261715], 30, {
-              units: 'meters',
-              properties: {
-                name: '测试点1',
-                lng: 120.104697,
-                lat: 30.260704,
-              },
-            }),
-          ]),
-        )
-        .color('#ff0000')
+        .source(featureCollection([]))
+        .color('rgba(255,255,255,0.2)')
         .shape('fill');
 
       const lineString = new LineLayer({
@@ -103,10 +82,17 @@ const Demo: FunctionComponent = () => {
         )
         .size(6)
         .color('#00ff00');
+
+      fetch('https://geo.datav.aliyun.com/areas_v3/bound/100000_full.json')
+        .then((res) => res.json())
+        .then((data) => {
+          polygonLayer.setData(data);
+        });
       newScene.addLayer(pointLayer);
       newScene.addLayer(polygonLayer);
       newScene.addLayer(lineString);
       const newPopup = new LayerPopup({
+        closeButton: true,
         items: [
           {
             title: (e) => {

--- a/packages/component/src/popup/popup.ts
+++ b/packages/component/src/popup/popup.ts
@@ -477,8 +477,16 @@ export default class Popup<O extends IPopupOption = IPopupOption>
 
       // this.closeButton.type = 'button';
       closeButton.setAttribute('aria-label', 'Close popup');
-      closeButton.addEventListener('click', () => {
+      closeButton.addEventListener('click', (e) => {
         this.hide();
+      });
+
+      // 防止点击 Popup 关闭按钮时，触发 Layer click 事件
+      closeButton.addEventListener('pointerup', (e) => {
+        e.stopPropagation();
+      });
+      closeButton.addEventListener('pointerdown', (e) => {
+        e.stopPropagation();
       });
 
       this.closeButton = closeButton;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fix #xxxx
-->

### 💡 需求背景和解决方案

拦截 closeButton DOM 对象的 pointerup 和 pointerdown 事件（Hammer.js 触发机制），从而避免事件冒泡导致的 Layer 的 click 事件被触发

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---
