### PR TITLE
fix: 图片图层在跨域请求的情况下不发送 cookies

### DIFF
--- a/packages/source/src/parser/image.ts
+++ b/packages/source/src/parser/image.ts
@@ -39,7 +39,7 @@ function loadData(data: string | string[], done: any) {
   const url = data;
   const imageDatas: Array<HTMLImageElement | ImageBitmap> = [];
   if (typeof url === 'string') {
-    getImage({ url }, (err, img) => {
+    getImage({ url, credentials: 'include' }, (err, img) => {
       if (img) {
         imageDatas.push(img);
         done(imageDatas);
@@ -49,7 +49,7 @@ function loadData(data: string | string[], done: any) {
     const imageCount = url.length;
     let imageindex = 0;
     url.forEach((item) => {
-      getImage({ url: item }, (err, img) => {
+      getImage({ url: item, credentials: 'include' }, (err, img) => {
         imageindex++;
         if (img) {
           imageDatas.push(img);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）


### 💡 需求背景和解决方案

目前图片图层在[跨域请求图片](https://developer.mozilla.org/zh-CN/docs/Web/API/Request/credentials)的情况下，不会带上 cookies

现在需要确定的是，source 是否需要添加上这个配置，还是默认内置带上 cookies


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---
