### PR TITLE
feat: 图片图层请求数据支持自定义参数

### DIFF
--- a/packages/source/src/parser/image.ts
+++ b/packages/source/src/parser/image.ts
@@ -1,19 +1,23 @@
 import { IParserData } from '@antv/l7-core';
-import { getImage, isImageBitmap } from '@antv/l7-utils';
+import { RequestParameters, getImage, isImageBitmap } from '@antv/l7-utils';
 interface IImageCfg {
   extent: [number, number, number, number];
+  requestParameters?: Omit<RequestParameters, 'url'>;
 }
 export default function image(
   data: string | string[] | HTMLImageElement | ImageBitmap,
   cfg: IImageCfg,
 ): IParserData {
   // 为 extent 赋默认值
-  const { extent = [121.168, 30.2828, 121.384, 30.4219] } = cfg;
+  const {
+    extent = [121.168, 30.2828, 121.384, 30.4219],
+    requestParameters = {},
+  } = cfg;
   const images = new Promise((resolve) => {
     if (data instanceof HTMLImageElement || isImageBitmap(data)) {
       resolve([data]);
     } else {
-      loadData(data, (res: any) => {
+      loadData(data, requestParameters, (res: any) => {
         resolve(res);
       });
     }
@@ -35,11 +39,14 @@ export default function image(
   return resultData;
 }
 
-function loadData(data: string | string[], done: any) {
-  const url = data;
+function loadData(
+  url: string | string[],
+  requestParameters: Omit<RequestParameters, 'url'>,
+  done: any,
+) {
   const imageDatas: Array<HTMLImageElement | ImageBitmap> = [];
   if (typeof url === 'string') {
-    getImage({ url }, (err, img) => {
+    getImage({ ...requestParameters, url }, (err, img) => {
       if (img) {
         imageDatas.push(img);
         done(imageDatas);
@@ -49,7 +56,7 @@ function loadData(data: string | string[], done: any) {
     const imageCount = url.length;
     let imageindex = 0;
     url.forEach((item) => {
-      getImage({ url: item }, (err, img) => {
+      getImage({ ...requestParameters, url: item }, (err, img) => {
         imageindex++;
         if (img) {
           imageDatas.push(img);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）


### 💡 需求背景和解决方案

图片图层在跨域请求的情况下不发送 cookies，现在允许图片图层在请求数据时自定义请求参数

带 cookies 使用方式如下：

```ts
const layer = new ImageLayer({})
.source(
    'https://gw.alipayobjects.com/zos/rmsportal/FnHFeFklTzKDdUESRNDv.jpg',
    {
      parser: {
        type: 'image',
        extent: [ 121.168, 30.2828, 121.384, 30.4219 ],
		requestParameters: { credentials: "include" }
      }
    }
  );
```


