### PR TITLE
fix: blend in device api

### DIFF
--- a/dev-demos/features/point/demos/circle-device.tsx
+++ b/dev-demos/features/point/demos/circle-device.tsx
@@ -48,12 +48,12 @@ export default () => {
               '#A6E1E0',
               '#B8EFE2',
               '#D7F9F0',
-            ]);
-          // .style({
-          //   opacity: 0.3,
-          //   strokeWidth: 0,
-          //   stroke: '#fff',
-          // });
+            ])
+            .style({
+              opacity: 0.3,
+              strokeWidth: 0,
+              stroke: '#fff',
+            });
           scene.addLayer(pointLayer);
           //  let i =0;
           // setInterval(() => {

--- a/packages/layers/src/core/BaseLayer.ts
+++ b/packages/layers/src/core/BaseLayer.ts
@@ -40,8 +40,8 @@ import {
   IPass,
   IPickingService,
   IPostProcessingPass,
-  IRenderOptions,
   IRendererService,
+  IRenderOptions,
   IScale,
   IScaleOptions,
   IShaderModuleService,
@@ -50,12 +50,12 @@ import {
   IStyleAttributeUpdateOptions,
   ITextureService,
   LayerEventType,
+  lazyInject,
   LegendItems,
   StyleAttributeField,
   StyleAttributeOption,
-  TYPES,
   Triangulation,
-  lazyInject,
+  TYPES,
 } from '@antv/l7-core';
 import Source from '@antv/l7-source';
 import { encodePickingColor, lodashUtil } from '@antv/l7-utils';
@@ -1385,7 +1385,7 @@ export default class BaseLayer<ChildLayerStyleOptions = {}>
           uniforms: this.layerModel.getUninforms(),
           blend: this.layerModel.getBlend(),
           stencil: this.layerModel.getStencil(options),
-          textures:this.layerModel.textures
+          textures: this.layerModel.textures,
         },
         options?.ispick || false,
       );
@@ -1498,8 +1498,7 @@ export default class BaseLayer<ChildLayerStyleOptions = {}>
     if (autoRender) {
       setTimeout(() => {
         this.reRender();
-      },10);
-     
+      }, 10);
     }
   };
 

--- a/packages/layers/src/plugins/PixelPickingPlugin.ts
+++ b/packages/layers/src/plugins/PixelPickingPlugin.ts
@@ -83,7 +83,7 @@ export default class PixelPickingPlugin implements ILayerPlugin {
         // float u_shaderPick;
         // float u_EnableSelect;
         // float u_activeMix;
-        data: new Float32Array(this.pickOption2Array().length),
+        data: new Float32Array(20),
         isUBO: true,
       });
       rendererService.uniformBuffers[1] = uniformBuffer;

--- a/packages/renderer/src/device/DeviceModel.ts
+++ b/packages/renderer/src/device/DeviceModel.ts
@@ -179,12 +179,12 @@ export default class DeviceModel implements IModel {
                     BlendFactor.ONE,
                   blendDstFactor:
                     (blendEnabled && blendParams.func.dstAlpha) ||
-                    BlendFactor.ONE_MINUS_SRC_ALPHA,
+                    BlendFactor.ONE,
                 },
               },
         ],
         blendConstant: blendEnabled ? TransparentBlack : undefined,
-        depthWrite: true,
+        depthWrite: depthEnabled,
         depthCompare:
           (depthEnabled && depthParams.func) || CompareFunction.LESS,
         cullMode: (cullEnabled && cullParams.face) || CullMode.NONE,
@@ -235,8 +235,6 @@ export default class DeviceModel implements IModel {
 
     // @ts-ignore
     const { width, height, renderPass } = this.device;
-
-    console.log('pick...', pick);
 
     // TODO: Recreate pipeline only when blend / cull changed.
     this.pipeline = this.createPipeline(mergedOptions, pick);

--- a/packages/renderer/src/device/index.ts
+++ b/packages/renderer/src/device/index.ts
@@ -122,21 +122,19 @@ export default class DeviceRendererService implements IRendererService {
   beginFrame(): void {
     const onscreenTexture = this.swapChain.getOnscreenTexture();
     const colorAttachment = this.currentFramebuffer
-      ? this.currentFramebuffer['colorRenderTarget']
+      ? this.currentFramebuffer['colorRenderTarget'] || null
       : this.mainColorRT;
     const depthStencilAttachment = this.currentFramebuffer
-      ? this.currentFramebuffer['depthRenderTarget']
+      ? this.currentFramebuffer['depthRenderTarget'] || null
       : this.mainDepthRT;
-
-    // @ts-ignore
-    this.device.renderPass = this.renderPass;
+    const depthClearValue = depthStencilAttachment ? 1 : undefined;
 
     this.renderPass = this.device.createRenderPass({
       colorAttachment: [colorAttachment],
       colorResolveTo: [this.currentFramebuffer ? null : onscreenTexture],
       colorClearColor: [TransparentBlack],
       depthStencilAttachment,
-      depthClearValue: 1,
+      depthClearValue,
     });
     // @ts-ignore
     this.device.renderPass = this.renderPass;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

使用 Device API 模式渲染下，开启 Blend 之后，拾取正常：

![Dec-06-2023 13-49-22](https://github.com/antvis/L7/assets/3608471/7d44b944-1a6c-43db-9930-cf402f55f63e)


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---
