### PR TITLE
fix: each layer should have its own picking ubo

### DIFF
--- a/dev-demos/features/mask/demos/singleMask.tsx
+++ b/dev-demos/features/mask/demos/singleMask.tsx
@@ -1,15 +1,15 @@
 // @ts-ignore
-import { Scene, PointLayer, PolygonLayer} from '@antv/l7';
+import { PointLayer, Scene } from '@antv/l7';
 // @ts-ignore
-import { GaodeMap } from '@antv/l7-maps';
+import { GaodeMap, Map } from '@antv/l7-maps';
 import React, { useEffect } from 'react';
 
 export default () => {
   useEffect(() => {
     const scene = new Scene({
       id: 'map',
-     
-      map: new GaodeMap({
+      renderer: process.env.renderer,
+      map: new (process.env.CI ? Map : GaodeMap)({
         center: [120.165, 30.26],
         pitch: 0,
         zoom: 15,
@@ -43,11 +43,15 @@ export default () => {
     };
 
     scene.on('loaded', () => {
-      const polygonLayer = new PolygonLayer().source(maskData).shape('fill').color('#f00').style({opacity:0.5});
-      
+      // const polygonLayer = new PolygonLayer()
+      //   .source(maskData)
+      //   .shape('fill')
+      //   .color('#f00')
+      //   .style({ opacity: 0.5 });
+
       let point1 = new PointLayer({
         zIndex: 1,
-        maskLayers: [polygonLayer],
+        // maskLayers: [polygonLayer],
       })
         .source(
           [
@@ -73,7 +77,7 @@ export default () => {
         .active(true);
 
       let point2 = new PointLayer({
-        maskLayers: [polygonLayer],
+        // maskLayers: [polygonLayer],
       })
         .source(
           [
@@ -97,8 +101,9 @@ export default () => {
         .active(true);
 
       scene.addLayer(point1);
-      scene.addLayer(polygonLayer);
+      // scene.addLayer(polygonLayer);
       scene.addLayer(point2);
+      // scene.startAnimate();
     });
   }, []);
   return (

--- a/dev-demos/features/point/demos/circle-device.tsx
+++ b/dev-demos/features/point/demos/circle-device.tsx
@@ -55,7 +55,7 @@ export default () => {
               stroke: '#fff',
             });
           scene.addLayer(pointLayer);
-          scene.startAnimate();
+          // scene.startAnimate();
           //  let i =0;
           // setInterval(() => {
           //     i++ % 2 === 0 ? pointLayer.setBlend('additive') : pointLayer.setBlend('normal');

--- a/packages/core/src/services/layer/ILayerService.ts
+++ b/packages/core/src/services/layer/ILayerService.ts
@@ -82,7 +82,7 @@ export interface ILayerModelInitializationOptions {
   vertexShader: string;
   fragmentShader: string;
   triangulation: Triangulation;
-  styleOption?: unknown,
+  styleOption?: unknown;
   workerEnabled?: boolean;
   workerOptions?: IWorkerOption;
 }
@@ -583,6 +583,16 @@ export interface ILayer {
 
   // 设置当前地球时间 控制太阳角度
   setEarthTime(time: number): void;
+
+  /**
+   * WebGL2 下更新 Layer 级 Uniform
+   */
+  getLayerUniformBuffer(): IBuffer;
+
+  /**
+   * WebGL2 下更新 Layer 级 Uniform
+   */
+  getPickingUniformBuffer(): IBuffer;
 }
 
 /**

--- a/packages/core/src/services/layer/LayerService.ts
+++ b/packages/core/src/services/layer/LayerService.ts
@@ -7,14 +7,8 @@ import Clock from '../../utils/clock';
 import type { IDebugService } from '../debug/IDebugService';
 import type { IMapService } from '../map/IMapService';
 import type { IRendererService } from '../renderer/IRendererService';
-import type {
-  ILayer,
-  ILayerService,
-  LayerServiceEvent} from './ILayerService';
-import {
-  MaskOperation,
-  StencilType,
-} from './ILayerService';
+import type { ILayer, ILayerService, LayerServiceEvent } from './ILayerService';
+import { MaskOperation, StencilType } from './ILayerService';
 const { throttle } = lodashUtil;
 @injectable()
 export default class LayerService

--- a/packages/core/src/shaders/scene_uniforms.glsl
+++ b/packages/core/src/shaders/scene_uniforms.glsl
@@ -3,7 +3,6 @@ layout(std140) uniform SceneUniforms {
   mat4 u_ProjectionMatrix;
   mat4 u_ViewProjectionMatrix;
   mat4 u_ModelMatrix;
-  mat4 u_Mvp;
   vec4 u_ViewportCenterProjection;
   vec3 u_PixelsPerDegree;
   float u_Zoom;
@@ -15,7 +14,10 @@ layout(std140) uniform SceneUniforms {
   float u_DevicePixelRatio;
   vec2 u_ViewportCenter;
   vec2 u_ViewportSize;
-  vec2 u_sceneCenterMercator;
   float u_FocalDistance;
-  float u_SceneUniformsPadding;
+};
+
+layout(std140) uniform LayerUniforms {
+  mat4 u_Mvp;
+  vec2 u_sceneCenterMercator;
 };

--- a/packages/renderer/src/device/DeviceBuffer.ts
+++ b/packages/renderer/src/device/DeviceBuffer.ts
@@ -1,9 +1,9 @@
 import type { Buffer, Device } from '@antv/g-device-api';
 import { BufferUsage } from '@antv/g-device-api';
-import type { IBuffer, IBufferInitializationOptions} from '@antv/l7-core';
+import type { IBuffer, IBufferInitializationOptions } from '@antv/l7-core';
 import { gl } from '@antv/l7-core';
 import { hintMap, typedArrayCtorMap } from './constants';
-import type { TypedArray} from './utils/typedarray';
+import type { TypedArray } from './utils/typedarray';
 import { isTypedArray } from './utils/typedarray';
 
 /**

--- a/packages/renderer/src/device/DeviceModel.ts
+++ b/packages/renderer/src/device/DeviceModel.ts
@@ -5,7 +5,8 @@ import type {
   InputLayout,
   InputLayoutBufferDescriptor,
   Program,
-  RenderPipeline} from '@antv/g-device-api';
+  RenderPipeline,
+} from '@antv/g-device-api';
 import {
   BlendFactor,
   BlendMode,
@@ -20,12 +21,16 @@ import type {
   IModel,
   IModelDrawOptions,
   IModelInitializationOptions,
-  IUniform} from '@antv/l7-core';
-import {
-  gl
+  IUniform,
 } from '@antv/l7-core';
+import { gl } from '@antv/l7-core';
 import { lodashUtil } from '@antv/l7-utils';
 import type DeviceRendererService from '.';
+import type DeviceAttribute from './DeviceAttribute';
+import type DeviceBuffer from './DeviceBuffer';
+import type DeviceElements from './DeviceElements';
+import DeviceFramebuffer from './DeviceFramebuffer';
+import DeviceTexture2D from './DeviceTexture2D';
 import {
   blendEquationMap,
   blendFuncMap,
@@ -34,11 +39,6 @@ import {
   primitiveMap,
   sizeFormatMap,
 } from './constants';
-import type DeviceAttribute from './DeviceAttribute';
-import type DeviceBuffer from './DeviceBuffer';
-import type DeviceElements from './DeviceElements';
-import DeviceFramebuffer from './DeviceFramebuffer';
-import DeviceTexture2D from './DeviceTexture2D';
 const { isPlainObject, isTypedArray } = lodashUtil;
 
 export default class DeviceModel implements IModel {

--- a/packages/renderer/src/device/index.ts
+++ b/packages/renderer/src/device/index.ts
@@ -2,7 +2,8 @@ import type {
   Device,
   RenderPass,
   RenderTarget,
-  SwapChain} from '@antv/g-device-api';
+  SwapChain,
+} from '@antv/g-device-api';
 import {
   Format,
   TextureUsage,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

目前多个图层无法单独拾取，原因是共用了一个全局 Picking Uniform Buffer。
每个 Layer 需要有自己单独的一个，但 Layer 中的多个 Model 可以共享。

另外 `u_Mvp` 这个高德地图下的 uniform 也应修改成 Layer 级而非全局，否则多个同类图层无法叠加。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---
