### PR TITLE
feat: 图层显隐控件配置更新时，新增处理单选模式图层显示逻辑

### DIFF
--- a/packages/component/src/control/layerSwitch.ts
+++ b/packages/component/src/control/layerSwitch.ts
@@ -108,19 +108,26 @@ export default class LayerSwitch extends SelectControl<ILayerSwitchOption> {
     const isLayerChange = this.checkUpdateOption(option, ['layers', 'multiple']);
     super.setOptions(option);
     if (isLayerChange) {
+      if (this.controlOption.multiple === false) {
+        this.handleSingleSelectionMode();
+      }
       this.selectValue = this.getLayerVisible();
       this.controlOption.options = this.getLayerOptions();
       this.popper.setContent(this.getPopperContent(this.controlOption.options));
     }
   }
 
+  // TODO: 单选模式下，目前默认展示第一项，通过用户提供defaultValue展示默认选项的属性待开发
+  // 如果是单选模式，则只显示第一个图层
+  private handleSingleSelectionMode() {
+    this.layers.forEach((layer, index) => {
+      index === 0 ? layer.show() : layer.hide();
+    });
+  }
+
   public onAdd(): HTMLElement {
-    // TODO: 单选模式下，目前默认展示第一项，通过用户提供defaultValue展示默认选项的属性待开发
-    // 如果是单选模式，则只显示第一个图层
     if (this.controlOption.multiple === false) {
-      this.layers.forEach((layer, index) => {
-        index === 0 ? layer.show() : layer.hide();
-      });
+      this.handleSingleSelectionMode()
     }
 
     if (!this.controlOption.options?.length) {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- ✅ 新特性提交

### 💡 需求背景和解决方案
当multiple属性更新时，若此时layer显示的有多个，图层显隐控件需要把显示的图层控制为一个，其他图层都隐藏

修改前：从多选模式切换为单选模式，单选器选择多个
<img src="https://github.com/antvis/L7/assets/18047832/98098843-02df-4e6d-99ad-531feea2f7b9" alt="image.png" width="50%" />

修改前：添加新图层，多选器选择了多个
<img src="https://github.com/antvis/L7/assets/18047832/30949abb-b205-4a28-a569-7678540f0d41" alt="image.png" width="50%" />

修改后：更新layers 和 multiple 属性时，都处理的单选值，都仅显示一个图层
<img src="https://github.com/antvis/L7/assets/18047832/dd171a32-1b3f-496f-b5f9-07957984a9f3" alt="image.png" width="50%" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- ☑️ 文档已补充或无须补充
- ☑️ 代码演示已提供或无须提供
- ☑️ TypeScript 定义已补充或无须补充
- ☑️ Changelog 已提供或无须提供

---
