### PR TITLE
fix: 新版高德大于 21 级别抖动问题

### DIFF
--- a/packages/maps/src/amap-next/map.ts
+++ b/packages/maps/src/amap-next/map.ts
@@ -118,13 +118,14 @@ export default class BMapService extends BaseMap<AMap.Map> {
   };
 
   private getViewState() {
+    const { center, zoom } = getMapHighPrecisionState(this.map);
     const option = {
-      center: [this.map.getCenter().getLng(), this.map.getCenter().getLat()] as [number, number],
+      center: center,
       viewportWidth: this.map.getContainer()!.clientWidth,
       viewportHeight: this.map.getContainer()!.clientHeight,
       bearing: -this.map.getRotation(),
       pitch: this.map.getPitch(),
-      zoom: this.map.getZoom() - ZOOM_OFFSET,
+      zoom: zoom - ZOOM_OFFSET,
     };
 
     return option;
@@ -436,4 +437,19 @@ export default class BMapService extends BaseMap<AMap.Map> {
     }
     this.map.destroy();
   }
+}
+
+/**
+ * 访问高精度的地图状态（临时解决方案）
+ * - 解决 map.getCenter() 方法只返回小数点五位有效数据
+ * - 解决 map.getZoom() 方法只返回小数点两位有效数据
+ */
+function getMapHighPrecisionState(map: AMap.Map) {
+  // @ts-expect-error 访问未暴露的内部属性
+  const viewStatus = map._view.getOptions();
+
+  const center: [number, number] = viewStatus.center;
+  const zoom: number = viewStatus.zoom;
+
+  return { center, zoom };
 }


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关背景

高德因返回地图中心数据点，截取了前五位，精度丢失造成数据抖动

- [地图大于 20 级数据抖动背景及方案提议](https://www.yuque.com/antv/l7/dicwnx6mh1e2nc81#zchc2)


<table>
<tr>
 <td>
before
 <td>
now
<tr>
 <td>


https://github.com/antvis/L7/assets/26923747/c548b083-4415-4906-8196-fe4467a69759



 <td>


https://github.com/antvis/L7/assets/26923747/c68dffcd-8d48-4936-8395-84899eee8173


</table>

