### PR TITLE
fix: raster with luminance in webgl1

### DIFF
--- a/packages/renderer/src/device/DeviceTexture2D.ts
+++ b/packages/renderer/src/device/DeviceTexture2D.ts
@@ -74,6 +74,8 @@ export default class DeviceTexture2D implements ITexture2D {
       pixelFormat = unorm ? Format.U8_RGBA_NORM : Format.U8_RGBA_RT;
     } else if (type === gl.UNSIGNED_BYTE && format === gl.LUMINANCE) {
       pixelFormat = Format.U8_LUMINANCE;
+    } else if (type === gl.FLOAT && format === gl.LUMINANCE) {
+      pixelFormat = Format.F32_LUMINANCE;
     } else if (type === gl.FLOAT && format === gl.RGB) {
       // @see https://github.com/antvis/L7/pull/2262
       if (this.device.queryVendorInfo().platformString === 'WebGPU') {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/L7/blob/master/.github/CONTRIBUTING.md

-->

[[English Template / 英文模板](https://github.com/antvis/L7/blob/master/.github/PULL_REQUEST_TEMPLATE_EN.md?plain=1)]

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fixed #xxxx
-->

### 💡 需求背景和解决方案

WebGL1 下需要使用 Format.F32_LUMINANCE

```ts
/**
 * WebGL1 allow the combination of gl.LUMINANCE & gl.FLOAT with OES_texture_float
 */
format: queryVerdorInfo() === 'WebGL1' ? gl.LUMINANCE : gl.RED,
type: gl.FLOAT,
```

但其实这种组合是不符合规范的：
https://github.com/antvis/L7/pull/2128#issuecomment-1851922960

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供

---
