### PR TITLE
fix: 修复 bindings 缓存在 WebGPU 的问题

### DIFF
--- a/.changeset/famous-geese-know.md
+++ b/.changeset/famous-geese-know.md
@@ -1,0 +1,5 @@
+---
+'@antv/l7-renderer': patch
+---
+
+fix: 修复 bindings 缓存在 WebGPU 的问题

--- a/packages/renderer/src/device/DeviceModel.ts
+++ b/packages/renderer/src/device/DeviceModel.ts
@@ -157,7 +157,6 @@ export default class DeviceModel implements IModel {
     const stencilEnabled = !!(stencilParams && stencilParams.enable);
 
     const pipeline = this.device.createRenderPipeline({
-      // return this.service.renderCache.createRenderPipeline({
       inputLayout: this.inputLayout,
       program: this.program,
       topology: primitiveMap[primitive],
@@ -270,7 +269,7 @@ export default class DeviceModel implements IModel {
       ...this.extractUniforms(uniforms),
     };
 
-    const { renderPass, currentFramebuffer, width, height, renderCache } = this.service;
+    const { renderPass, currentFramebuffer, width, height } = this.service;
 
     // TODO: Recreate pipeline only when blend / cull changed.
     this.pipeline = this.createPipeline(mergedOptions, pick);
@@ -311,8 +310,7 @@ export default class DeviceModel implements IModel {
         : null,
     );
     if (uniformBuffers) {
-      // this.bindings = device.createBindings({
-      this.bindings = renderCache.createBindings({
+      this.bindings = device.createBindings({
         pipeline: this.pipeline,
         uniformBufferBindings: uniformBuffers.map((uniformBuffer, i) => {
           const buffer = uniformBuffer as DeviceBuffer;


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fixed #xxxx
-->

- #2431
- #2525

### 💡 问题出现原因

在 WebGPU 下，每次 model draw 创建新 Pipeline，使用了缓存 createBindings，导致新的 Pipeline 使用 [getBindGroupLayout](https://developer.mozilla.org/en-US/docs/Web/API/GPUComputePipeline/getBindGroupLayout) 不一致。

因 L7 API 设计原因，draw 动态传入的参数（比如 stencil），必须每次创建 Pipeline，后续设计新 API 考虑 Pipeline 缓存情况。