### PR TITLE
fix: setBgColor not applying background color to map container (Issue #2549)

### DIFF
--- a/packages/maps/src/map/map.ts
+++ b/packages/maps/src/map/map.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+ 
 /**
  * MapboxService
  */
@@ -131,6 +131,13 @@ export default class DefaultMapService extends BaseMapService<Map> {
 
   public exportMap(type: 'jpg' | 'png'): string {
     return '';
+  }
+
+  public setBgColor(color: string) {
+    this.bgColor = color;
+    if (this.$mapContainer) {
+      this.$mapContainer.style.backgroundColor = color;
+    }
   }
 
   public setMapStyle(style: any): void {}


### PR DESCRIPTION
## 描述

修复 Issue #2549: scene.setBgColor 在 2.22.0 版本中失效

## 问题原因

`setBgColor` 方法只设置了 `this.bgColor` 属性，但没有实际更新地图容器的背景色样式。

## 修复内容

- 在 `DefaultMapService` 中覆盖 `setBgColor` 方法
- 设置 bgColor 属性的同时，更新 `$mapContainer` 的 CSS `background-color` 样式

## 测试

- [ ] 在 SimpleMap 模式下测试 setBgColor 方法

Closes #2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)