### PR TITLE
fix: MarkerLayer hide/show use display instead of opacity (Issue #2696)

### DIFF
--- a/packages/component/src/marker-layer.ts
+++ b/packages/component/src/marker-layer.ts
@@ -207,7 +207,7 @@ export default class MarkerLayer extends EventEmitter {
         if (typeof m.hide === 'function') {
           m.hide();
         } else {
-          m.getElement().style.opacity = '0';
+          m.getElement().style.display = 'none';
         }
       } catch (e) {
         void e;
@@ -219,7 +219,7 @@ export default class MarkerLayer extends EventEmitter {
         if (typeof m.hide === 'function') {
           m.hide();
         } else {
-          m.getElement().style.opacity = '0';
+          m.getElement().style.display = 'none';
         }
       } catch (e) {
         void e;
@@ -236,7 +236,7 @@ export default class MarkerLayer extends EventEmitter {
         if (typeof m.show === 'function') {
           m.show();
         } else {
-          m.getElement().style.opacity = '1';
+          m.getElement().style.display = 'block';
         }
       } catch (e) {
         void e;
@@ -248,7 +248,7 @@ export default class MarkerLayer extends EventEmitter {
         if (typeof m.show === 'function') {
           m.show();
         } else {
-          m.getElement().style.opacity = '1';
+          m.getElement().style.display = 'block';
         }
       } catch (e) {
         void e;


### PR DESCRIPTION
## 描述

修复 Issue #2696: MarkerLayer hide/show 方法使用 opacity 控制显示隐藏，导致隐藏的 DOM 元素仍然占据空间并拦截点击事件。

## 问题原因

`hide()` 方法中使用 `style.opacity = 0` 和 `show()` 方法中使用 `style.opacity = 1`，这种方式虽然在视觉上隐藏了元素，但 DOM 元素仍然占据空间并能拦截底层元素的点击事件。

## 修复内容

将 opacity 改为 display 控制：
- `hide()`: 使用 `style.display = none`
- `show()`: 使用 `style.display = block`

## 代码变更

- `packages/component/src/marker-layer.ts`: 修改 hide() 和 show() 方法

## 测试

- [x] 验证 hide 后元素不阻挡点击事件
- [x] 验证 show 后元素正常显示

Closes #2696

🤖 Generated with AI Assistant