### PR TITLE
fix: LineLayer shape 切换后重建模型

### DIFF
--- a/packages/layers/src/line/index.ts
+++ b/packages/layers/src/line/index.ts
@@ -34,6 +34,10 @@ export default class LineLayer extends BaseLayer<ILineLayerStyleOptions> {
     await this.initLayerModels();
   }
 
+  public async rebuildModels() {
+    await this.buildModels();
+  }
+
   protected getDefaultConfig() {
     const type = this.getModelType();
     const defaultConfig = {


### PR DESCRIPTION
## 问题
修复 Issue #2714: 线图层shape默认line，切换到arc，再切回来，图层消失

## 原因
当调用 `layer.shape()` 方法改变 shape 时，没有触发模型重建。

## 解决方案
在 LineLayer 中重写 `rebuildModels` 方法，类似于 PointLayer 的做法，在 shape 改变后调用 `buildModels` 重建模型。

## 测试
```javascript
const layer = new LineLayer()
  .source(data)
  .shape(line)
  .style({ stroke: #f00 })

// 切换到 arc 
layer.shape("arc")

// 再切回 line - 之前会消失，现在应该正常显示
layer.shape("line")
```