### PR TITLE
fix: normalize longitude for popup coordinates (#2692)

### DIFF
--- a/packages/component/src/popup/popup.ts
+++ b/packages/component/src/popup/popup.ts
@@ -397,7 +397,14 @@ export default class Popup<O extends IPopupOption = IPopupOption>
       return;
     }
     const { lng, lat } = this.lngLat;
-    const { x, y } = this.mapsService.lngLatToContainer([lng, lat]);
+    // Normalize longitude to -180 ~ 180 range
+    let normalizedLng = lng;
+    if (lng > 180) {
+      normalizedLng = lng - 360 * Math.floor((lng + 180) / 360);
+    } else if (lng < -180) {
+      normalizedLng = lng + 360 * Math.floor((-lng + 180) / 360);
+    }
+    const { x, y } = this.mapsService.lngLatToContainer([normalizedLng, lat]);
 
     this.setPopupPosition(x, y);
   };


### PR DESCRIPTION
## 描述
修复 Issue #2692: Popup 如果坐标点的经度大于180度，弹出框不会在实际经度弹出

## 问题
当 Popup 坐标的经度大于 180 度时，Popup 会在错误的位置显示。

## 解决方案
在将经纬度转换为容器坐标之前，先将经度标准化到 -180 ~ 180 范围内。

## 修改内容
- `packages/component/src/popup/popup.ts`: 在 `updateLngLatPosition` 方法中添加经度标准化逻辑

## 测试
- [ ] 手动验证经度 > 180 度时 Popup 位置正确
- [ ] 手动验证经度 < -180 度时 Popup 位置正确
- [ ] 手动验证正常经度范围 (-180 ~ 180) 不受影响

Closes #2692

🤖 Generated with Claude Code