### PR TITLE
fix: pass preserveDrawingBuffer to Mapbox for screenshot support (#2723)

### DIFF
--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -85,6 +85,7 @@ export default class MapboxService extends BaseMapService<Map & IMapboxInstance>
       token,
       rotation = 0,
       mapInstance,
+      preserveDrawingBuffer,
       ...rest
     } = this.config;
 
@@ -128,7 +129,7 @@ export default class MapboxService extends BaseMapService<Map & IMapboxInstance>
         style: this.getMapStyleValue(style),
         attributionControl,
         bearing: rotation,
-        ...rest,
+        preserveDrawingBuffer: preserveDrawingBuffer ?? undefined,
       });
     }
     this.map.on('load', () => {


### PR DESCRIPTION
修复 Issue #2723: 配置 preserveDrawingBuffer: true 截图不生效

当使用 Mapbox 地图时，需要将 preserveDrawingBuffer 选项传递给 Mapbox 实例的 WebGL 上下文，这样才能使用 html2canvas 等工具正确截图。

修改内容:
- 从 MapboxService 配置中提取 preserveDrawingBuffer 参数
- 传递给 Mapbox 构造函数

---