### PR TITLE
fix: resolve .less import issue in ES build (#2844)

### DIFF
--- a/packages/component/.fatherrc.ts
+++ b/packages/component/.fatherrc.ts
@@ -4,7 +4,16 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 export default defineConfig({
   extends: '../../.fatherrc.base.ts',
-  // 使用 babel 编译 esm/cjs 产物，启用 transform-import-css-l7 插件完成 CSS 内联打包
-  esm: { transformer: 'babel' },
-  cjs: isProduction ? { transformer: 'babel' } : undefined,
+  // Fix: 使用 esbuild transformer 来正确处理 CSS/LESS 导入
+  // esbuild 可以正确地将 .less 导入转换为内联 CSS
+  esm: {
+    transformer: 'esbuild',
+    platform: 'browser',
+  },
+  cjs: isProduction
+    ? {
+        transformer: 'esbuild',
+        platform: 'node',
+      }
+    : undefined,
 });


### PR DESCRIPTION
## 修复描述

修复 issue #2844：@antv/l7-component ES build 导入 .less 源文件的问题。

### 问题
从 v2.24.0 开始，`@antv/l7-component/es/index.js` 导入了 `.less` 文件：
```js
import "./css/index.less";
```
这导致任何通过 Vite 或其他 bundler 构建的项目，如果没有安装 `less` 作为依赖，都会出现构建失败。

### 解决方案
将 `.fatherrc.ts` 中的 babel transformer 改为 esbuild。esbuild 可以正确地将 .less 导入转换为内联 CSS，而不需要消费者安装 less 预处理器。

### 修改文件
- `packages/component/.fatherrc.ts`：将 esm 和 cjs 的 transformer 从 babel 改为 esbuild

### 测试
此修复需要在发布新版本后进行验证，确保 ES build 输出不再包含对 .less 文件的直接引用。

---

**相关 Issue**: #2844