### PR TITLE
fix: resolve ES build importing .less source files (fix #2844)

### DIFF
--- a/packages/component/.fatherrc.ts
+++ b/packages/component/.fatherrc.ts
@@ -7,4 +7,14 @@ export default defineConfig({
   // 使用 babel 编译 esm/cjs 产物，启用 transform-import-css-l7 插件完成 CSS 内联打包
   esm: { transformer: 'babel' },
   cjs: isProduction ? { transformer: 'babel' } : undefined,
+  // 确保 CSS 被打包到产物中而不是直接引用 less 源文件
+  extraBabelPlugins: [
+    [
+      // import glsl as raw text
+      'babel-plugin-inline-import',
+      { extensions: '.glsl' },
+    ],
+    // import css as inline
+    'transform-import-css-l7',
+  ],
 });


### PR DESCRIPTION
## 修复内容

修复 Issue #2844: @antv/l7-component ES build imports .less source files since v2.24.0

### 问题描述
- 从 v2.24.0 开始，`@antv/l7-component/es/index.js` 中直接导入了 `.less` 文件：
  ```js
  import "./css/index.less";
  ```
- 这会导致没有安装 `less` 预处理器的项目构建失败

### 问题原因
- 当使用 babel transformer 构建 ESM 时，缺少 `extraBabelPlugins` 配置来正确处理 CSS 内联

### 解决方案
- 在 `.fatherrc.ts` 中添加 `extraBabelPlugins` 配置，包含 `transform-import-css-l7` 插件
- 这确保 CSS 在构建时被正确内联到产物中，而不是直接引用 less 源文件

### 受影响版本
- 2.24.0 – 2.25.4 (latest)

### 测试
- 构建 `@antv/l7-component` 包，确认 ES 模块产物不再包含 `.less` 导入

Related: #2844