### PR TITLE
fix: comment out .less import to avoid requiring less preprocessor

### DIFF
--- a/packages/component/src/index.ts
+++ b/packages/component/src/index.ts
@@ -3,7 +3,7 @@ import MarkerLayer from './marker-layer';
 
 import './assets/iconfont/iconfont.js';
 // 引入样式
-import './css/index.less';
+// import './css/index.less'; /* 注释掉以避免消费者必须安装 less */
 
 export * from './control/baseControl';
 export { ExportImage, type IExportImageControlOption } from './control/exportImage';


### PR DESCRIPTION
## 描述
修复 Issue #2844

## 问题
自 v2.24.0 起，`@antv/l7-component/es/index.js` 导入了 .less 源文件：
```js
import "./css/index.less";
```

这会导致通过传递依赖（如 @ant-design/maps 或 @ant-design/charts）依赖 @antv/l7 的项目，在没有安装 less 作为开发依赖时构建失败。

## 修改内容
- `packages/component/src/index.ts`: 注释掉 `.less` 导入，恢复 v2.23.x 的行为

## 测试
- [x] 本地构建通过
- [ ] 需要在有 less 预处理器和无 less 预处理器两种环境下验证

Closes #2844

🤖 Generated with Claude Code