### PR TITLE
fix: enable animate option for GaodeMap fitBounds (fix #2704)

### DIFF
--- a/packages/maps/src/amap-next/map.ts
+++ b/packages/maps/src/amap-next/map.ts
@@ -306,11 +306,14 @@ export default class BMapService extends BaseMap<AMap.Map> {
     this.map.panBy(x, y);
   }
 
-  public fitBounds(extent: Bounds): void {
+  public fitBounds(extent: Bounds, fitBoundsOptions?: any): void {
+    const animate = fitBoundsOptions?.animate ?? false;
     this.map.setBounds(
       new AMap.Bounds([extent[0][0], extent[0][1], extent[1][0], extent[1][1]]),
-      // @ts-expect-error 立即缩放到指定位置
+      // @ts-expect-error 第二个参数配置
       true,
+      // @ts-expect-error animate 参数，控制动画效果
+      animate,
     );
   }
 


### PR DESCRIPTION
修复 Issue #2704: 当使用GaodeMap时，scene.fitBounds(bounds, {animate: true})无动画效果

## 修改内容
- 为高德地图的 fitBounds 方法添加 fitBoundsOptions 参数支持
- 从 fitBoundsOptions 中提取 animate 参数并传递给高德地图的 setBounds 方法
- 默认 animate 为 false，保持原有行为

## 影响范围
只影响高德地图 (amap-next)，其他地图保持不变。

## 测试方法
```javascript
scene.fitBounds(bounds, { animate: true });
```

使用高德地图时，现在应该有过渡动画效果。