### PR TITLE
fix: 修复天地图图层被覆盖的问题 (#2852)

### DIFF
--- a/packages/maps/src/tdtmap/map.ts
+++ b/packages/maps/src/tdtmap/map.ts
@@ -116,6 +116,7 @@ export default class TdtMapService extends BaseMapService<any> {
     overlayPane.parentElement.appendChild(container);
     container.id = 'tdt-L7';
     const size = this.map.getSize();
+    container.style.position = 'relative'; // 修复天地图图层被覆盖的问题
     container.style.zIndex = '200'; //置于上层
     container.style.width = `${size.x}px`;
     container.style.height = `${size.y}px`;


### PR DESCRIPTION
修复 Issue #2852: 天地图的组件被地图覆盖

## 问题原因
- .tdt-pane 设置了 position: absolute
- #tdt-L7 容器继承了父元素的定位方式
- 导致 L7 图层被天地图底图覆盖

## 解决方案
- 为 #tdt-L7 容器添加 position: relative 样式
- 使其建立新的定位上下文，防止被父元素覆盖

## 测试
请验证天地图示例中 PointLayer 等图层能够正常显示在地图上方，不再被地图覆盖。

Reference: #2852

🤖 Generated with WeaveFox