### PR TITLE
feat(maps): 支持自定义高德地图 JS 版本

### DIFF
--- a/packages/maps/src/amap-next/map.ts
+++ b/packages/maps/src/amap-next/map.ts
@@ -51,6 +51,7 @@ export default class AMapService extends BaseMap<AMap.Map> {
       token,
       mapInstance,
       plugin = [],
+      version = AMAP_VERSION,
       ...rest
     } = this.config;
 
@@ -65,7 +66,7 @@ export default class AMapService extends BaseMap<AMap.Map> {
       plugin.push('Map3D');
       await AMapLoader.load({
         key: amapKey, // 申请好的Web端开发者Key，首次调用 load 时必填
-        version: AMAP_VERSION, // 指定要加载的 JSAPI 的版本
+        version: version, // 指定要加载的 JSAPI 的版本
         plugins: plugin, // 需要使用的的插件列表，如比例尺'AMap.Scale'等
       });
     }


### PR DESCRIPTION
## 修复 Issue #2862

### 问题描述
用户希望能够自定义高德地图的 JS 版本，而不是使用硬编码的 2.0 版本。

### 解决方案
在 `init` 方法中添加 `version` 配置项，允许用户通过传入配置参数自定义版本，默认为 `AMAP_VERSION` (2.0)。

### 代码修改
- 在配置解构中添加 `version = AMAP_VERSION`
- 将 `AMapLoader.load` 中的 `version` 参数改为使用配置值

### 使用示例
```javascript
new GaodeMap({
  version: '1.4.15',  // 指定高德地图 JS 版本
  token: 'your-token',
  style: 'light'
});
```

### 相关 Issue
- Close #2862