### PR TITLE
test(utils): Add prototype pollution regression tests

### DIFF
--- a/packages/utils/__tests__/pp-check.spec.ts
+++ b/packages/utils/__tests__/pp-check.spec.ts
@@ -1,0 +1,49 @@
+import { lodashUtil } from '../src/lodash-adapter';
+
+const { merge, mergeWith } = lodashUtil;
+
+/**
+ * 原型污染回归测试。
+ *
+ * 复现社区安全报告中的攻击链：用户可控的图层配置最终流入
+ * `globalConfigService.setLayerConfig()` -> `lodashUtil.merge()`。
+ * 若 merge 递归遍历 source 时不过滤 `__proto__` / `constructor` / `prototype`，
+ * 由 JSON 解析得到的恶意 config 会污染 `Object.prototype`。
+ */
+describe('lodash-adapter prototype pollution', () => {
+  const pollutionKey = 'l7_pp_regression';
+
+  afterEach(() => {
+    delete (Object.prototype as any)[pollutionKey];
+  });
+
+  it('merge should not pollute Object.prototype via __proto__', () => {
+    const malicious = JSON.parse(`{"__proto__":{"${pollutionKey}":"PWNED"}}`);
+    merge({}, {}, malicious);
+    expect((Object.prototype as any)[pollutionKey]).toBeUndefined();
+  });
+
+  it('merge should not pollute Object.prototype via constructor.prototype', () => {
+    const malicious = JSON.parse(`{"constructor":{"prototype":{"${pollutionKey}":"PWNED"}}}`);
+    merge({}, malicious);
+    expect((Object.prototype as any)[pollutionKey]).toBeUndefined();
+  });
+
+  it('mergeWith should not pollute Object.prototype via __proto__', () => {
+    const malicious = JSON.parse(`{"__proto__":{"${pollutionKey}":"PWNED"}}`);
+    mergeWith({}, malicious, () => undefined);
+    expect((Object.prototype as any)[pollutionKey]).toBeUndefined();
+  });
+
+  it('mergeWith should not pollute Object.prototype via constructor.prototype', () => {
+    const malicious = JSON.parse(`{"constructor":{"prototype":{"${pollutionKey}":"PWNED"}}}`);
+    mergeWith({}, malicious, () => undefined);
+    expect((Object.prototype as any)[pollutionKey]).toBeUndefined();
+  });
+
+  it('merge should still deep-merge legitimate keys', () => {
+    const target = { a: 1, nested: { x: 1 } };
+    const result = merge(target, { b: 2, nested: { y: 2 } });
+    expect(result).toEqual({ a: 1, b: 2, nested: { x: 1, y: 2 } });
+  });
+});


### PR DESCRIPTION
### 改动描述

- Add `pp-check.spec.ts` to guard `lodash-adapter` merge functions
- Verify `merge` and `mergeWith` ignore `__proto__` payloads
- Verify `constructor.prototype` payloads do not pollute `Object.prototype`
- Ensure legitimate deep merging still works as expected



### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 版本更新
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
2. 例如 close #xxxx、 fixed #xxxx
-->
https://github.com/antvis/L7/pull/2861
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | X |
| 🇨🇳 中文 |          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
