### PR TITLE
fix(ci): pin pnpm to 11.12.0 to avoid 11.13.0 install regression

### DIFF
--- a/.github/actions/prepare-install/action.yml
+++ b/.github/actions/prepare-install/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v3
       with:
-        version: 11
+        version: 11.12.0
 
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v4


### PR DESCRIPTION
## 问题
最近所有基于 master 的新 PR，CI 的 `lint` / `unit-test` / `size-test` 三个 job 都在 **install 阶段 ~10s 内失败**：

```
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
For help, run: pnpm help install
##[error]Process completed with exit code 1.
```

复现 PR（与各自代码改动无关，均在 install 阶段崩）：
- #2874（纯删 10 个死文件）
- #2875（仅改 2 个 map.ts）

## 根因
`.github/actions/prepare-install/action.yml` 用浮动版本：
```yaml
- uses: pnpm/action-setup@v3
  with:
    version: 11      # 解析到最新 11.x = 11.13.0
```
`version: 11` 近期解析到**新发布的 pnpm 11.13.0**，它与当前 lockfile（由 `pnpm@11.12.0` 生成）不兼容，在 `pnpm install` 解析 lockfile 时崩溃。

对照证据：更早的 PR（#2863 / #2856 / #2853 等）跑 `lint (20.x)` 全 pass、耗时 2 分钟+（真正跑了测试）——彼时 11.x 还解析到 11.12.0/更早版本；近期 11.13.0 发布后才 regression。

## 修复
固定为 `11.12.0`，与 `package.json` 的 `packageManager: "pnpm@11.12.0"` 一致：

```diff
-        version: 11
+        version: 11.12.0
```

## 验证
本 PR 的 CI 会用固定后的 11.12.0 运行 —— 若 install 通过、lint/unit/size 正常跑起来，即验证修复。

## 说明
- `action-setup@v3` 本身可读 `packageManager` 字段，但仅在未显式传 `version` 时。当前 action 显式传了 `version: 11` 会覆盖，故需显式 pin。
- 合并后，依赖此基线的 PR（#2874 / #2875 等）重跑 CI 即可变绿。
