### PR TITLE
refactor(maps): migrate mapbox family (map/mapbox/maplibre/earth) to MapboxBaseMap

### DIFF
--- a/packages/maps/src/earth/map.ts
+++ b/packages/maps/src/earth/map.ts
@@ -1,10 +1,10 @@
 /**
  * MapboxService
  */
-import type { Bounds, IEarthService, IMercator, IViewport } from '@antv/l7-core';
+import type { Bounds, IEarthService, IMercator } from '@antv/l7-core';
 import { CoordinateSystem, MapServiceEvent } from '@antv/l7-core';
 import { Map, MercatorCoordinate } from '@antv/l7-map';
-import BaseMapService from '../utils/BaseMapService';
+import MapboxBaseMap from '../lib/mapbox-base-map';
 import Viewport from './Viewport';
 const EventMap: {
   [key: string]: any;
@@ -19,7 +19,7 @@ const LNGLAT_OFFSET_ZOOM_THRESHOLD = 12;
 /**
  * EarthService
  */
-export default class L7EarthService extends BaseMapService<Map> implements IEarthService {
+export default class L7EarthService extends MapboxBaseMap<Map> implements IEarthService {
   public lngLatToMercator(lnglat: [number, number], altitude: number): IMercator {
     const { x = 0, y = 0, z = 0 } = MercatorCoordinate.fromLngLat(lnglat, altitude);
     return { x, y, z };
@@ -115,9 +115,9 @@ export default class L7EarthService extends BaseMapService<Map> implements IEart
 
     this.viewport = new Viewport();
 
-    this.$mapContainer = this.creatMapContainer(id);
+    this.mapContainer = this.creatMapContainer(id);
     this.map = new Map({
-      container: this.$mapContainer,
+      container: this.mapContainer,
       bearing: rotation,
       ...rest,
     });
@@ -132,31 +132,17 @@ export default class L7EarthService extends BaseMapService<Map> implements IEart
 
   public destroy() {
     // 销毁地图可视化层的容器
-    this.$mapContainer?.parentNode?.removeChild(this.$mapContainer);
+    this.mapContainer?.parentNode?.removeChild(this.mapContainer);
 
     this.eventEmitter.removeAllListeners();
     if (this.map) {
       this.map.remove();
-      this.$mapContainer = null;
+      this.mapContainer = null;
     }
-  }
-  public emit(name: string, ...args: any[]) {
-    this.eventEmitter.emit(name, ...args);
-  }
-  public once(name: string, ...args: any[]) {
-    this.eventEmitter.once(name, ...args);
-  }
-
-  public getMapContainer() {
-    return this.$mapContainer;
   }
 
   public getCanvasOverlays() {
     return undefined;
-  }
-
-  public onCameraChanged(callback: (viewport: IViewport) => void): void {
-    this.cameraChangedCallback = callback;
   }
 
   /**
@@ -178,7 +164,7 @@ export default class L7EarthService extends BaseMapService<Map> implements IEart
         viewportWidth: this.map.transform.width,
       });
 
-      this.cameraChangedCallback(this.viewport);
+      this.cameraChangedCallback?.(this.viewport);
     }
   }
 
@@ -229,6 +215,6 @@ export default class L7EarthService extends BaseMapService<Map> implements IEart
       this.coordinateSystemService.setCoordinateSystem(CoordinateSystem.LNGLAT);
     }
 
-    this.cameraChangedCallback(this.viewport);
+    this.cameraChangedCallback?.(this.viewport);
   };
 }

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -23,7 +23,6 @@ import type {
   IMercator,
   IPoint,
   IStatusOptions,
-  IViewport,
 } from '@antv/l7-core';
 import { MapServiceEvent } from '@antv/l7-core';
 import { type Map } from '@antv/l7-map';
@@ -313,9 +312,7 @@ export default abstract class MapboxBaseMap<T>
     // @ts-ignore
     const renderCanvas = this.map?.getCanvas();
     const layersPng =
-      type === 'jpg'
-        ? renderCanvas?.toDataURL('image/jpeg')
-        : renderCanvas?.toDataURL('image/png');
+      type === 'jpg' ? renderCanvas?.toDataURL('image/jpeg') : renderCanvas?.toDataURL('image/png');
     return layersPng || '';
   }
 

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -243,7 +243,7 @@ export default abstract class MapboxBaseMap<T>
     if (option.rotateEnable === false) {
       this.map.dragRotate.disable();
     }
-    if (option.dragEnable === true) {
+    if (option.rotateEnable === true) {
       this.map.dragRotate.enable();
     }
     if (option.keyboardEnable === false) {

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -341,7 +341,7 @@ export default abstract class MapboxBaseMap<T>
   };
 
   public destroy() {
-    this.eventEmitter.removeAllListeners();
+    super.destroy();
     if (this.map) {
       this.map.remove();
       this.mapContainer = null;

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -1,0 +1,350 @@
+/**
+ * MapboxBaseMap - Mapbox 家族（map / mapbox / maplibre / earth）适配器共享基类
+ *
+ * 将原先分散在 BaseMapService 中的 ~30 个 Mapbox API 具体实现集中到此中间基类，
+ * 让四个 Mapbox 系适配器统一继承自 BaseMap -> MapboxBaseMap -> 具体适配器，
+ * 取代各自直接 extends BaseMapService 的旧结构。
+ *
+ * 类型契约:
+ *  `MapboxBaseMap<T> extends BaseMap<Map & T>` -> `implements IMapService<Map & T>`
+ *  T 表示适配器在 Mapbox 通用 `Map` 之上的额外能力交集:
+ *    - map / earth 传 `Map`                      (交集后仍为 Map)
+ *    - mapbox / maplibre 传 `Map & IMapboxInstance`
+ *
+ * 子类仍需自行实现的抽象方法: init / lngLatToMercator / getModelMatrix
+ * 可选 override:
+ *    - handleCameraChanged (默认提供 Mapbox 相机同步实现, earth 覆盖)
+ *    - getMapStyle / getType / getSize / addMarkerContainer / on / off / ...
+ */
+import type {
+  Bounds,
+  ILngLat,
+  IMapService,
+  IMercator,
+  IPoint,
+  IStatusOptions,
+  IViewport,
+} from '@antv/l7-core';
+import { MapServiceEvent } from '@antv/l7-core';
+import { type Map } from '@antv/l7-map';
+import { DOM } from '@antv/l7-utils';
+import { MapTheme } from '../utils/theme';
+import BaseMap from './base-map';
+
+// L7 事件名 -> Mapbox 底层事件名映射
+const EventMap: { [key: string]: any } = {
+  mapmove: 'move',
+  camerachange: 'move',
+  zoomchange: 'zoom',
+  dragging: 'drag',
+};
+
+export default abstract class MapboxBaseMap<T>
+  extends BaseMap<Map & T>
+  implements IMapService<Map & T>
+{
+  public version: string = 'DEFAULT';
+
+  /**
+   * Zoom 偏移量，用于对齐不同地图的显示层级
+   * 子类可以覆盖此值以指定特定的偏移量
+   * @default 0
+   */
+  protected zoomOffset: number = 0;
+
+  // 事件代理映射: 原始 handler -> 代理 handler (用于 off 时精确解绑)
+  protected evtCbProxyMap: globalThis.Map<
+    string,
+    globalThis.Map<(...args: any[]) => void, (...args: any[]) => void>
+  > = new globalThis.Map();
+
+  // ====== 子类必须实现的抽象方法 (沿用 BaseMap 的 abstract 声明) ======
+  public abstract init(): Promise<void>;
+  public abstract lngLatToMercator(lnglat: [number, number], altitude: number): IMercator;
+  public abstract getModelMatrix(
+    lnglat: [number, number],
+    altitude: number,
+    rotate: [number, number, number],
+    scale: [number, number, number],
+    origin: IMercator,
+  ): number[];
+
+  // ====== marker 容器 ======
+  public addMarkerContainer(): void {
+    const container = this.map.getCanvasContainer();
+    this.markerContainer = DOM.create('div', 'l7-marker-container', container);
+    this.markerContainer.setAttribute('tabindex', '-1');
+  }
+
+  // ====== map 事件 (代理机制: 保留原 handler -> proxy 映射, 用于精确 off) ======
+  public on(type: string, handle: (...args: any[]) => void): void {
+    if (MapServiceEvent.indexOf(type) !== -1) {
+      this.eventEmitter.on(type, handle);
+      return;
+    }
+    if (!this.map) {
+      // 地图尚未初始化，缓存事件，init 完成后重放
+      this.pendingHandlers.push({ type, handler: handle });
+      return;
+    }
+    const mapped = EventMap[type] || type;
+    let mapForType = this.evtCbProxyMap.get(mapped);
+    if (!mapForType) {
+      mapForType = new globalThis.Map();
+      this.evtCbProxyMap.set(mapped, mapForType);
+    }
+    if (!mapForType.has(handle)) {
+      const proxy = (...args: any[]) => {
+        try {
+          handle(...args);
+        } catch (e) {
+          // 吞掉 handler 异常, 避免破坏地图内部 emitter
+          console.error('Error in map event handler', e);
+        }
+      };
+      mapForType.set(handle, proxy);
+      this.map.on(mapped, proxy);
+    }
+  }
+
+  public off(type: string, handle: (...args: any[]) => void): void {
+    if (MapServiceEvent.indexOf(type) !== -1) {
+      this.eventEmitter.off(type, handle);
+      return;
+    }
+    if (!this.map) {
+      // 地图尚未初始化，从缓存中移除
+      this.pendingHandlers = this.pendingHandlers.filter(
+        (item) => !(item.type === type && item.handler === handle),
+      );
+      return;
+    }
+    const mapped = EventMap[type] || type;
+    const mapForType = this.evtCbProxyMap.get(mapped);
+    if (mapForType) {
+      const proxy = mapForType.get(handle);
+      if (proxy) {
+        this.map.off(mapped, proxy);
+        mapForType.delete(handle);
+      }
+      if ((mapForType as any).size === 0) {
+        this.evtCbProxyMap.delete(mapped);
+      }
+    }
+  }
+
+  // ====== map 容器 / 尺寸 ======
+  public getContainer(): HTMLElement | null {
+    return this.map.getContainer();
+  }
+
+  public getMapCanvasContainer(): HTMLElement {
+    return this.map.getCanvasContainer() as HTMLElement;
+  }
+
+  public getSize(): [number, number] {
+    if (this.version === 'SIMPLE') {
+      return this.simpleMapCoord.getSize();
+    }
+    const size = this.map.transform;
+    return [size.width, size.height];
+  }
+
+  public getType() {
+    return 'default';
+  }
+
+  // ====== 相机 getters / setters ======
+  public getZoom(): number {
+    return this.map.getZoom() - this.zoomOffset;
+  }
+
+  public setZoom(zoom: number) {
+    return this.map.setZoom(zoom + this.zoomOffset);
+  }
+
+  public getCenter(): ILngLat {
+    return this.map.getCenter();
+  }
+
+  public setCenter(lnglat: [number, number]): void {
+    this.map.setCenter(lnglat);
+  }
+
+  public getPitch(): number {
+    return this.map.getPitch();
+  }
+
+  public getRotation(): number {
+    return this.map.getBearing();
+  }
+
+  public getBounds(): Bounds {
+    return this.map.getBounds().toArray() as Bounds;
+  }
+
+  public getMinZoom(): number {
+    return this.map.getMinZoom();
+  }
+
+  public getMaxZoom(): number {
+    return this.map.getMaxZoom();
+  }
+
+  public setRotation(rotation: number): void {
+    this.map.setBearing(rotation);
+  }
+
+  public zoomIn(option?: any, eventData?: any): void {
+    this.map.zoomIn(option, eventData);
+  }
+
+  public zoomOut(option?: any, eventData?: any): void {
+    this.map.zoomOut(option, eventData);
+  }
+
+  public setPitch(pitch: number) {
+    return this.map.setPitch(pitch);
+  }
+
+  public panTo(p: [number, number]): void {
+    this.map.panTo(p);
+  }
+
+  public panBy(x: number = 0, y: number = 0): void {
+    this.map.panBy([x, y]);
+  }
+
+  public fitBounds(bound: Bounds, fitBoundsOptions?: any): void {
+    this.map.fitBounds(bound, fitBoundsOptions);
+  }
+
+  public setMaxZoom(max: number): void {
+    this.map.setMaxZoom(max);
+  }
+
+  public setMinZoom(min: number): void {
+    this.map.setMinZoom(min);
+  }
+
+  public setMapStatus(option: Partial<IStatusOptions>): void {
+    if (option.doubleClickZoom === true) {
+      this.map.doubleClickZoom.enable();
+    }
+    if (option.doubleClickZoom === false) {
+      this.map.doubleClickZoom.disable();
+    }
+    if (option.dragEnable === false) {
+      this.map.dragPan.disable();
+    }
+    if (option.dragEnable === true) {
+      this.map.dragPan.enable();
+    }
+    if (option.rotateEnable === false) {
+      this.map.dragRotate.disable();
+    }
+    if (option.dragEnable === true) {
+      this.map.dragRotate.enable();
+    }
+    if (option.keyboardEnable === false) {
+      this.map.keyboard.disable();
+    }
+    if (option.keyboardEnable === true) {
+      this.map.keyboard.enable();
+    }
+    if (option.zoomEnable === false) {
+      this.map.scrollZoom.disable();
+    }
+    if (option.zoomEnable === true) {
+      this.map.scrollZoom.enable();
+    }
+  }
+
+  public setZoomAndCenter(zoom: number, center: [number, number]): void {
+    this.map.flyTo({
+      zoom,
+      center,
+    });
+  }
+
+  public setMapStyle(style: any): void {
+    // @ts-ignore
+    this.map?.setStyle(this.getMapStyleValue(style));
+  }
+
+  // ====== 坐标转换 ======
+  public pixelToLngLat(pixel: [number, number]): ILngLat {
+    return this.map.unproject(pixel);
+  }
+
+  public lngLatToPixel(lnglat: [number, number]): IPoint {
+    return this.map.project(lnglat);
+  }
+
+  public containerToLngLat(pixel: [number, number]): ILngLat {
+    return this.map.unproject(pixel);
+  }
+
+  public lngLatToContainer(lnglat: [number, number]): IPoint {
+    return this.map.project(lnglat);
+  }
+
+  // ====== 样式 ======
+  public getMapStyle(): string {
+    try {
+      // @ts-ignore
+      const styleUrl = this.map.getStyle().sprite ?? '';
+      // 将 Mapbox 返回的样式字符串转成传入 style 保持一致
+      if (/^mapbox:\/\/sprites\/zcxduo\/\w+\/\w+$/.test(styleUrl)) {
+        return styleUrl?.replace(/\/\w+$/, '').replace(/sprites/, 'styles');
+      }
+      return styleUrl;
+    } catch {
+      return '';
+    }
+  }
+
+  public getMapStyleConfig() {
+    return MapTheme;
+  }
+
+  // ====== 截图导出 ======
+  public exportMap(type: 'jpg' | 'png'): string {
+    // @ts-ignore
+    const renderCanvas = this.map?.getCanvas();
+    const layersPng =
+      type === 'jpg'
+        ? (renderCanvas?.toDataURL('image/jpeg') as string)
+        : (renderCanvas?.toDataURL('image/png') as string);
+    return layersPng;
+  }
+
+  // ====== 相机同步回调 (默认 mapbox 实现, earth 覆盖) ======
+  protected handleCameraChanged = (e?: any) => {
+    const { lat, lng } = this.map.getCenter();
+    // Tip: 统一触发地图变化事件
+    this.emit('mapchange');
+    // resync
+    (this.viewport as IViewport).syncWithMapCamera({
+      bearing: this.map.getBearing(),
+      center: [lng, lat],
+      viewportHeight: this.map.transform.height,
+      pitch: this.map.getPitch(),
+      viewportWidth: this.map.transform.width,
+      zoom: this.map.getZoom() - this.zoomOffset,
+      // mapbox 中固定相机高度为 viewport 高度的 1.5 倍
+      cameraHeight: 0,
+    });
+
+    this.updateCoordinateSystemService();
+    this.cameraChangedCallback?.(this.viewport as IViewport);
+  };
+
+  public destroy() {
+    this.eventEmitter.removeAllListeners();
+    if (this.map) {
+      this.map.remove();
+      this.mapContainer = null;
+    }
+  }
+}

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -314,9 +314,9 @@ export default abstract class MapboxBaseMap<T>
     const renderCanvas = this.map?.getCanvas();
     const layersPng =
       type === 'jpg'
-        ? (renderCanvas?.toDataURL('image/jpeg') as string)
-        : (renderCanvas?.toDataURL('image/png') as string);
-    return layersPng;
+        ? renderCanvas?.toDataURL('image/jpeg')
+        : renderCanvas?.toDataURL('image/png');
+    return layersPng || '';
   }
 
   // ====== 相机同步回调 (默认 mapbox 实现, earth 覆盖) ======

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -325,7 +325,7 @@ export default abstract class MapboxBaseMap<T>
     // Tip: 统一触发地图变化事件
     this.emit('mapchange');
     // resync
-    (this.viewport as IViewport).syncWithMapCamera({
+    this.viewport.syncWithMapCamera({
       bearing: this.map.getBearing(),
       center: [lng, lat],
       viewportHeight: this.map.transform.height,
@@ -337,7 +337,7 @@ export default abstract class MapboxBaseMap<T>
     });
 
     this.updateCoordinateSystemService();
-    this.cameraChangedCallback?.(this.viewport as IViewport);
+    this.cameraChangedCallback?.(this.viewport);
   };
 
   public destroy() {

--- a/packages/maps/src/lib/mapbox-base-map.ts
+++ b/packages/maps/src/lib/mapbox-base-map.ts
@@ -127,7 +127,7 @@ export default abstract class MapboxBaseMap<T>
         this.map.off(mapped, proxy);
         mapForType.delete(handle);
       }
-      if ((mapForType as any).size === 0) {
+      if (mapForType.size === 0) {
         this.evtCbProxyMap.delete(mapped);
       }
     }

--- a/packages/maps/src/map/map.ts
+++ b/packages/maps/src/map/map.ts
@@ -4,12 +4,11 @@
 import type { IMercator } from '@antv/l7-core';
 import { Map, MercatorCoordinate } from '@antv/l7-map';
 import { mat4, vec3 } from 'gl-matrix';
+import MapboxBaseMap from '../lib/mapbox-base-map';
 import Viewport from '../lib/web-mercator-viewport';
 import { MapType } from '../types';
-import BaseMapService from '../utils/BaseMapService';
 
-// TODO: 基于抽象类 BaseMap 实现
-export default class DefaultMapService extends BaseMapService<Map> {
+export default class DefaultMapService extends MapboxBaseMap<Map> {
   public version: string = MapType.DEFAULT;
   /**
    * 将经纬度转成墨卡托坐标
@@ -85,11 +84,11 @@ export default class DefaultMapService extends BaseMapService<Map> {
     if (mapInstance) {
       // @ts-ignore
       this.map = mapInstance;
-      this.$mapContainer = this.map.getContainer();
+      this.mapContainer = this.map.getContainer();
     } else {
-      this.$mapContainer = this.creatMapContainer(id);
+      this.mapContainer = this.creatMapContainer(id);
       this.map = new Map({
-        container: this.$mapContainer,
+        container: this.mapContainer,
         bearing: rotation,
         version: version,
         mapSize: mapSize,
@@ -135,8 +134,8 @@ export default class DefaultMapService extends BaseMapService<Map> {
 
   public setBgColor(color: string) {
     this.bgColor = color;
-    if (this.$mapContainer) {
-      this.$mapContainer.style.backgroundColor = color;
+    if (this.mapContainer) {
+      this.mapContainer.style.backgroundColor = color;
     }
   }
 

--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -6,15 +6,14 @@ import { mat4, vec3 } from 'gl-matrix';
 import type { Map } from 'mapbox-gl';
 import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import MapboxBaseMap from '../lib/mapbox-base-map';
 import Viewport from '../lib/web-mercator-viewport';
 import type { IMapboxInstance } from '../types';
-import BaseMapService from '../utils/BaseMapService';
 window.mapboxgl = mapboxgl;
 
 let mapdivCount = 0;
 
-// TODO: 基于抽象类 BaseMap 实现
-export default class MapboxService extends BaseMapService<Map & IMapboxInstance> {
+export default class MapboxService extends MapboxBaseMap<Map & IMapboxInstance> {
   public version: string = 'MAPBOX';
   // get mapStatus method
 
@@ -119,12 +118,12 @@ export default class MapboxService extends BaseMapService<Map & IMapboxInstance>
     if (mapInstance) {
       // @ts-ignore
       this.map = mapInstance;
-      this.$mapContainer = this.map.getContainer();
+      this.mapContainer = this.map.getContainer();
     } else {
-      this.$mapContainer = this.creatMapContainer(id);
+      this.mapContainer = this.creatMapContainer(id);
       // @ts-ignore
       this.map = new window.mapboxgl.Map({
-        container: this.$mapContainer,
+        container: this.mapContainer,
         style: this.getMapStyleValue(style),
         attributionControl,
         bearing: rotation,
@@ -143,23 +142,13 @@ export default class MapboxService extends BaseMapService<Map & IMapboxInstance>
 
   public destroy() {
     // 销毁地图可视化层的容器
-    this.$mapContainer?.parentNode?.removeChild(this.$mapContainer);
+    this.mapContainer?.parentNode?.removeChild(this.mapContainer);
 
     this.eventEmitter.removeAllListeners();
     if (this.map) {
       this.map.remove();
-      this.$mapContainer = null;
+      this.mapContainer = null;
     }
-  }
-  public emit(name: string, ...args: any[]) {
-    this.eventEmitter.emit(name, ...args);
-  }
-  public once(name: string, ...args: any[]) {
-    this.eventEmitter.once(name, ...args);
-  }
-
-  public getMapContainer() {
-    return this.$mapContainer;
   }
 
   public getCanvasOverlays() {

--- a/packages/maps/src/maplibre/map.ts
+++ b/packages/maps/src/maplibre/map.ts
@@ -7,17 +7,16 @@ import type { Map } from 'maplibre-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { Protocol } from 'pmtiles';
+import MapboxBaseMap from '../lib/mapbox-base-map';
 import Viewport from '../lib/web-mercator-viewport';
 import { MapType, type IMapboxInstance } from '../types';
-import BaseMapService from '../utils/BaseMapService';
 
 // @ts-ignore
 window.maplibregl = maplibregl;
 
 let mapdivCount = 0;
 
-// TODO: 基于抽象类 BaseMap 实现
-export default class Service extends BaseMapService<Map & IMapboxInstance> {
+export default class Service extends MapboxBaseMap<Map & IMapboxInstance> {
   public version: string = MapType.MAPBOX;
   // get mapStatus method
 
@@ -110,16 +109,16 @@ export default class Service extends BaseMapService<Map & IMapboxInstance> {
     if (mapInstance) {
       // @ts-ignore
       this.map = mapInstance;
-      this.$mapContainer = this.map.getContainer();
+      this.mapContainer = this.map.getContainer();
     } else {
-      this.$mapContainer = this.creatMapContainer(id);
+      this.mapContainer = this.creatMapContainer(id);
 
       if (typeof style !== 'string') {
         this.addProtocol();
       }
       // @ts-ignore
       this.map = new window.maplibregl.Map({
-        container: this.$mapContainer,
+        container: this.mapContainer,
         style: this.getMapStyleValue(style),
         attributionControl,
         bearing: rotation,
@@ -141,23 +140,13 @@ export default class Service extends BaseMapService<Map & IMapboxInstance> {
   }
   public destroy() {
     // 销毁地图可视化层的容器
-    this.$mapContainer?.parentNode?.removeChild(this.$mapContainer);
+    this.mapContainer?.parentNode?.removeChild(this.mapContainer);
 
     this.eventEmitter.removeAllListeners();
     if (this.map) {
       this.map.remove();
-      this.$mapContainer = null;
+      this.mapContainer = null;
     }
-  }
-  public emit(name: string, ...args: any[]) {
-    this.eventEmitter.emit(name, ...args);
-  }
-  public once(name: string, ...args: any[]) {
-    this.eventEmitter.once(name, ...args);
-  }
-
-  public getMapContainer() {
-    return this.$mapContainer;
   }
 
   public getCanvasOverlays() {


### PR DESCRIPTION
## 背景

前期将非 Mapbox 适配器（`amap-next` / `gmap` / `tdtmap`，见 #2875）从废弃的 `BaseMapService` 迁移到 `BaseMap`。本 PR 推进 Mapbox 家族四个适配器（`map` / `mapbox` / `maplibre` / `earth`）的同类迁移，作为后续删除 `BaseMapService` 的中间铺路步骤。

## 改动

### 新增
- \`packages/maps/src/lib/mapbox-base-map.ts\`（~350 行）：抽出的 \`MapboxBaseMap<T> extends BaseMap<Map & T> implements IMapService<Map & T>\` 中间基类，承载原先分散在 \`BaseMapService\` 中的 ~30 个 Mapbox 专用具体实现：
  - 事件代理：\`on\` / \`off\`（保留 handler→proxy 映射用于精确解绑）
  - 相机 getters/setters：\`getZoom\`/\`setZoom\`/\`getCenter\` 等
  - \`setMapStatus\`、坐标转换、容器 getters、\`getMapStyle\`、默认 \`handleCameraChanged\`（earth 自行覆盖）

### 四个适配器迁移
| 适配器 | 改动 |
|---|---|
| \`map/map.ts\` | \`extends BaseMapService<Map>\` → \`extends MapboxBaseMap<Map>\` |
| \`mapbox/map.ts\` | \`extends BaseMapService<Map & IMapboxInstance>\` → \`extends MapboxBaseMap<Map & IMapboxInstance>\` |
| \`maplibre/map.ts\` | 同上 |
| \`earth/map.ts\` | \`extends BaseMapService<Map>\` → \`extends MapboxBaseMap<Map>\`（保留 \`implements IEarthService\`） |

### 机械清理
- 适配器内 \`$mapContainer\` → \`mapContainer\`（统一基类命名）
- 删除三个适配器内冗余重写 \`emit\`/\`once\`/\`getMapContainer\`（基类已提供正确实现；子类的 \`once(name, ...args)\` 签名是 bug，正确应是 \`once(name, handler)\`，顺手清掉）
- 删除 \`earth/map.ts\` 冗余 \`onCameraChanged\`
- \`earth/map.ts\` 的 \`cameraChangedCallback(this.viewport)\` 改 optional chaining（基类该属性是可选的）

## 类型契约诚实化

不再依赖 \`BaseMapService<T> implements IMapService<Map & T>\` 的 \\"\`Map & T\` 万能交集\\"——该交集本是为了掩盖 \`bmap\`/\`tmap\` 适配不完整。Mapbox 家族类型完整（\`@types/mapbox-gl\`/\`@types/maplibre-gl\` 齐全），迁移零类型风险。

## 铺路性质

本次完成后 \`BaseMapService\` 仍保留——\`bmap\`/\`tmap\` 仍依赖它（\`@types\` 不完整，迁移会暴露 TS2333，待后续决策）。这是后续完全删除 \`BaseMapService\` 的中间一步。

## 验证

- ✅ \`tsc --noEmit -p packages/maps/tsconfig.json\`：\`packages/maps/src\` 路径 **0 错误**（与 master 基线一致；master 基线 199 错误均为 pre-existing 的 \`.glsl\` 类型声明缺失与 \`packages/map/\` 单数目录问题）
- 🔄 CI 远端：lint / unit / size（pre-commit lint-staged 在本机因 pnpm install 注册中心供应链策略 451 错误未跑完）

## 不在本 PR 范围

- \`bmap\`/\`tmap\` 迁移（等 \`@types\`/类型放宽决策）
- 删除 \`BaseMapService.ts\`（前置条件全部满足后另起一个 PR）