### PR TITLE
fix(maps): 修复 tdtmap/tmap 的 once() throw stub，清理冗余 override

### DIFF
--- a/packages/maps/src/amap-next/map.ts
+++ b/packages/maps/src/amap-next/map.ts
@@ -275,10 +275,6 @@ export default class AMapService extends BaseMap<AMap.Map> {
     ];
   }
 
-  public getMapContainer() {
-    return this.mapContainer;
-  }
-
   public getMapCanvasContainer(): HTMLElement {
     return this.map.getContainer()?.getElementsByClassName('amap-maps')[0] as HTMLElement;
   }

--- a/packages/maps/src/gmap/map.ts
+++ b/packages/maps/src/gmap/map.ts
@@ -232,10 +232,6 @@ export default class GMapService extends BaseMap<any> {
     }
   }
 
-  public onCameraChanged(callback: (viewport: IViewport) => void): void {
-    this.cameraChangedCallback = callback;
-  }
-
   private styleObserver: MutationObserver | null = null;
 
   public addMarkerContainer(): void {
@@ -438,10 +434,6 @@ export default class GMapService extends BaseMap<any> {
       [sw.lng(), sw.lat()],
       [ne.lng(), ne.lat()],
     ];
-  }
-
-  public setBgColor(color: string): void {
-    this.bgColor = color;
   }
 
   public setMapStyle(style: any): void {

--- a/packages/maps/src/tdtmap/map.ts
+++ b/packages/maps/src/tdtmap/map.ts
@@ -55,9 +55,6 @@ export default class TdtMapService extends BaseMap<any> {
     return this.markerContainer;
   }
 
-  public onCameraChanged(callback: (viewport: IViewport) => void): void {
-    this.cameraChangedCallback = callback;
-  }
   private resize(ev: any) {
     this.sceneContainer.style.width = ev.newSize.x + 'px';
     this.sceneContainer.style.height = ev.newSize.y + 'px';
@@ -298,10 +295,6 @@ export default class TdtMapService extends BaseMap<any> {
     } else {
       offProxy(EventMap[type] || type);
     }
-  }
-
-  public once(type: string, handler: (...args: any[]) => void): void {
-    throw new Error('Method not implemented.');
   }
 
   // get dom

--- a/packages/maps/src/tmap/map.ts
+++ b/packages/maps/src/tmap/map.ts
@@ -267,10 +267,6 @@ export default class TMapService extends BaseMapService<TMap.Map> {
     }
   }
 
-  public once(): void {
-    throw new Error('Method not implemented.');
-  }
-
   // get dom
   public getContainer(): HTMLElement | null {
     return this.map.getContainer();


### PR DESCRIPTION
## 背景
基座改造 (#2875 #2877 #2878) 过程中发现一个潜在的运行时 bug + 一批迁移后冗余的 override。本 PR 收敛处理。

## Bugfix: `once()` throw stub

`tdtmap/map.ts` 与 `tmap/map.ts` 的 `once()` 方法是 `throw new Error('Method not implemented.')` 的空 stub，其中 tmap 甚至把签名降级成 `once(): void`。

```ts
// tdtmap/map.ts (原 L303)
public once(type: string, handler: (...args: any[]) => void): void {
  throw new Error('Method not implemented.');
}
// tmap/map.ts (原 L270, 签名甚至丢了参数)
public once(): void {
  throw new Error('Method not implemented.');
}
```

### 影响面
`scene/src/index.ts:362` 有 `this.mapService.once(type, handle)`，使用 tdtmap / tmap 作为地图底图时该调用**直接抛异常**。

### 修复
二者基类均已提供可用实现：
- tdtmap `extends BaseMap` → `BaseMap.once = this.eventEmitter.once(name, handler)`
- tmap `extends BaseMapService` → `BaseMapService.once = this.eventEmitter.once(name, ...args)`

**删除 stub 即可让 once 正常继承基类实现工作**。tmap 的 stub 还误把可用基类实现覆盖坏了,删除后恢复正确行为。

## Cleanup: 冗余 override (逐字节与基类一致，行为不变)

迁移到 `BaseMap` / `MapboxBaseMap` 后, 以下 override 与基类实现完全相同, 纯死代码:

| 文件 | 方法 |
|---|---|
| `gmap/map.ts` | `onCameraChanged`, `setBgColor` |
| `tdtmap/map.ts` | `onCameraChanged` |
| `amap-next/map.ts` | `getMapContainer` (`return this.mapContainer;`) |

均为机械删除, **不改运行时行为**。

## 不在本 PR 范围
- `bmap/map.ts` 的 `onCameraChanged`/`once` 同样冗余, 但 bmap 正在 #2878 中迁移 base class, 为避免双 PR 同改一文件留待 #2878 合并后清理。
- `creatMapContainer` 在 mapbox 家族 (map/mapbox/maplibre/tdtmap) 重复了 `getElementById` 解析逻辑, 可后续 DRY 到 `super.creatMapContainer` 调用, 但属语义重构, 单独立项。

## 验证
- `tsc --noEmit -p packages/maps` 仅 4 个本地 `@types` 全局错误 (baseline)
- 受影响文件 (tdtmap/tmap/gmap/amap-next) 无新增 ts 错误
- prettier format-check 全绿
- 净变更: 4 files changed, **23 deletions(-)**