### PR TITLE
refactor(maps): DRY creatMapContainer 解析逻辑，复用 super 调用

### DIFF
--- a/packages/maps/src/map/map.ts
+++ b/packages/maps/src/map/map.ts
@@ -113,10 +113,7 @@ export default class DefaultMapService extends MapboxBaseMap<Map> {
   }
 
   protected creatMapContainer(id: string | HTMLDivElement) {
-    let wrapper = id as HTMLDivElement;
-    if (typeof id === 'string') {
-      wrapper = document.getElementById(id) as HTMLDivElement;
-    }
+    const wrapper = super.creatMapContainer(id);
     const container = document.createElement('div');
     container.style.cssText += `
       position: absolute;

--- a/packages/maps/src/mapbox/map.ts
+++ b/packages/maps/src/mapbox/map.ts
@@ -191,10 +191,7 @@ export default class MapboxService extends MapboxBaseMap<Map & IMapboxInstance> 
   }
 
   protected creatMapContainer(id: string | HTMLDivElement) {
-    let $wrapper = id as HTMLDivElement;
-    if (typeof id === 'string') {
-      $wrapper = document.getElementById(id) as HTMLDivElement;
-    }
+    const $wrapper = super.creatMapContainer(id);
     const $amapdiv = document.createElement('div');
     $amapdiv.style.cssText += `
       position: absolute;

--- a/packages/maps/src/maplibre/map.ts
+++ b/packages/maps/src/maplibre/map.ts
@@ -189,10 +189,7 @@ export default class Service extends MapboxBaseMap<Map & IMapboxInstance> {
   }
 
   protected creatMapContainer(id: string | HTMLDivElement) {
-    let $wrapper = id as HTMLDivElement;
-    if (typeof id === 'string') {
-      $wrapper = document.getElementById(id) as HTMLDivElement;
-    }
+    const $wrapper = super.creatMapContainer(id);
     const $amapdiv = document.createElement('div');
     $amapdiv.style.cssText += `
       position: absolute;

--- a/packages/maps/src/tdtmap/map.ts
+++ b/packages/maps/src/tdtmap/map.ts
@@ -527,10 +527,7 @@ export default class TdtMapService extends BaseMap<any> {
   }
 
   protected creatMapContainer(id: string | HTMLDivElement) {
-    let $wrapper = id as HTMLDivElement;
-    if (typeof id === 'string') {
-      $wrapper = document.getElementById(id) as HTMLDivElement;
-    }
+    const $wrapper = super.creatMapContainer(id);
     const $tdtmapdiv = document.createElement('div');
     $tdtmapdiv.style.cssText += `
       position: absolute;


### PR DESCRIPTION
## 背景
`BaseMap.creatMapContainer` 已封装 id-or-element 的解析逻辑（string 走 `getElementById`，`HTMLDivElement` 直接用）。`map` / `mapbox` / `maplibre` / `tdtmap` 四个适配器的 `creatMapContainer` 重写各自重复实现了一遍同样的解析，与基类逻辑冗余。

## 改动
将 4 个文件中重复的 id/element 解析分支替换为 `super.creatMapContainer(id)` 调用：

- `packages/maps/src/map/map.ts`
- `packages/maps/src/mapbox/map.ts`
- `packages/maps/src/maplibre/map.ts`
- `packages/maps/src/tdtmap/map.ts`

每个文件其余逻辑保持不变，行为与改动前**完全一致**：
- 创建内部 div（`$amapdiv` / `$tdtmapdiv` / `container`）
- 注入 `cssText`（position/top/height/width）
- 设置 id 前缀（`l7_mapbox_div` / `l7_tdt_div`）与 `mapdivCount++`
- 返回内部 div

`amap-next/map.ts` 早已通过 `super.creatMapContainer(id)` 调用基类，无需改动。

## 为何不把内部 div 创建也抽到 `MapboxBaseMap`
- `tdtmap` 继承 `BaseMap` 而非 `MapboxBaseMap`，无法复用 `MapboxBaseMap` 上的方法；
- 各适配器 id 前缀、变量命名不同，统一抽取会引入少量行为/样式调整的风险，收益有限；
- 本次只消除最明显的重复（id/element 解析），保留各适配器现有差异点，行为完全等价。

## 验证
- 本地 `tsc --noEmit -p packages/maps/tsconfig.json` 通过（除已知 `@types` 噪声外无报错）
- `prettier --check` 4 个改动文件通过

## 改动规模
净 -12 行（+4 / -16）