### PR TITLE
refactor(core): drop redundant viewport-mercator-project dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,13 +27,11 @@
     "@turf/helpers": "^6.1.4",
     "eventemitter3": "^4.0.0",
     "gl-matrix": "^3.1.0",
-    "hammerjs": "^2.0.8",
-    "viewport-mercator-project": "^6.2.1"
+    "hammerjs": "^2.0.8"
   },
   "devDependencies": {
     "@types/gl-matrix": "^2.4.5",
-    "@types/hammerjs": "^2.0.46",
-    "@types/viewport-mercator-project": "^6.1.0"
+    "@types/hammerjs": "^2.0.46"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,9 +289,6 @@ importers:
       hammerjs:
         specifier: ^2.0.8
         version: 2.0.8
-      viewport-mercator-project:
-        specifier: ^6.2.1
-        version: 6.2.3
     devDependencies:
       '@types/gl-matrix':
         specifier: ^2.4.5
@@ -299,9 +296,6 @@ importers:
       '@types/hammerjs':
         specifier: ^2.0.46
         version: 2.0.46
-      '@types/viewport-mercator-project':
-        specifier: ^6.1.0
-        version: 6.1.6
 
   packages/l7:
     dependencies:


### PR DESCRIPTION
## What

`packages/core/package.json` declared both `viewport-mercator-project` and `@types/viewport-mercator-project` as direct deps, but `packages/core/src` never actually imports the package — the only mention is a documentation URL comment in `CoordinateSystemService.ts:124`, which is not a code usage.

This PR removes the redundant declarations from core.

The real runtime consumer is `packages/maps/src/lib/web-mercator-viewport.ts` (value `import WebMercatorViewport from 'viewport-mercator-project'`, exercised by all 8 map adapters). `packages/maps/src/earth/Viewport.ts` uses an `import type` for an interface-only field that is never instantiated and whose `projectFlat` is never called from `earth/map.ts` — also covered by the maps-scope declaration, not core's.

The maps package therefore retains its own declaration and the workspace dependency graph is essentially unchanged — `pnpm-lock.yaml` only drops the importer-of-record lines for core (-6 lines).

## Why now (modernization investigation)

A prior turn looked into modernizing `viewport-mercator-project` to the latest npm tag. Findings:

- The npm-latest tag (`7.0.4`) is **deprecated** by vis.gl and is literally `module.exports = require('@math.gl/web-mercator')` under the hood.
- The underlying `@math.gl/web-mercator@4.1.0` uses a different projection convention — no `2^zoom` scaling on `projectFlat` / `center`, and substantially different matrix conventions.
- Runtime comparison at the same `{width,height,longitude,latitude,zoom,pitch,bearing}` options showed a `2^zoom` factor divergence in `projectFlat` / `center`, which would break L7's rendering pipeline downstream (layers / shaders / `CameraService`).
- **v6.2.3 itself is *not* deprecated** — only the npm-latest wrapper is. So staying on v6.2.3 is fine.

A full migration to the latest is therefore **out of scope** for this PR. The only uncontroversially-safe cleanup is removing core's dead direct declaration — which is what this commit does.

A future "vendor v6 source into the repo" PR (preserve v6 behavior exactly, remove the external dep completely) is feasible but requires its own risk review and visual regression pass, and is **not** in scope here.

## Changes

- `packages/core/package.json` — removed `viewport-mercator-project` (^6.2.1) from `dependencies`, `@types/viewport-mercator-project` (^6.1.0) from `devDependencies`.
- `pnpm-lock.yaml` — drops 6 lines (the importer-of-record entry for core; the package itself stays because maps still uses it transitively).

`packages/maps/package.json` is intentionally **untouched** — maps is the legitimate consumer.

## Validation

- Core `tsc --noEmit -p packages/core/tsconfig.json`: clean.
- Maps `tsc --noEmit -p packages/maps/tsconfig.json`: only pre-existing baseline noise (`.glsl` module resolution + unrelated `camera.ts` undefined checks); no new errors from this change.
- `prettier` (CI's `check-format.sh` glob `**/*.{ts,tsx,js,jsx,json,md,css,less}`): `packages/core/package.json` clean. (Lockfile yaml is outside CI's prettier glob.)

## Risk

Zero runtime risk — core has no actual code usage of the package. Maps and the rest of the rendering pipeline are untouched.
