### PR TITLE
fix(maps): 补全 BMap/TMap SDK 类型声明，修复 dts 生成失败

### DIFF
--- a/.changeset/fix-maps-bmap-tmap-types.md
+++ b/.changeset/fix-maps-bmap-tmap-types.md
@@ -1,0 +1,33 @@
+---
+'@antv/l7-maps': patch
+---
+
+fix(maps): 补全 BMap/TMap SDK 类型声明，修复 father dts 生成失败
+
+PR #2878 将 bmap/tmap 迁移到 BaseMap 后，maps 包全量 build 在
+father 的 declaration 生成阶段中断 (exit 1)，阻塞 fixed group
+整体发布。根因是第三方 SDK 类型缺失运行时存在、但 .d.ts 未声明的
+成员：
+
+- @types/bmapgl 的 BMapGL.Map 未声明 on/off/getMinZoom/getMaxZoom
+  (bmap/map.ts 直接 this.map.on(...)/getMinZoom() 调用报 TS2339/2551)
+- @map-component/tmap-types 的 TMap.Map 未声明 getContainer/panBy
+  (tmap/map.ts 7 处 getContainer + panBy 报 TS2339，连带
+  addEventListener 回调 e 隐式 any)
+
+修法 (补类型声明，非 as any 投机转换):
+
+- 新增 packages/maps/map-sdk-augmentation.d.ts (ambient，与现有
+  style.d.ts 同级，tsconfig 默认 include 覆盖):
+  通过 namespace 接口合并为 BMapGL.Map 补 on/off/getMinZoom/
+  getMaxZoom，为 TMap.Map 补 getContainer()/panBy([x,y])。
+  无运行时代码，仅声明增强。
+- bmap/map.ts: 补 public version: string = BMAP_VERSION 声明
+  (对齐 maplibre/map.ts、map/map.ts 惯例；此前只赋值未声明)
+- bmap/tmap map.ts: handleCameraChanged 中
+  this.cameraChangedCallback(...) 改 ?. 可选调用，与 BaseMap
+  updateView 一致 (cameraChangedCallback 为可选属性)
+
+验证: pnpm --filter @antv/l7-maps build 0 error (48 files)，
+pnpm 全量 build 通过 (fixed group 解除阻塞)，eslint 0 error。
+无运行时行为变更。

--- a/packages/maps/map-sdk-augmentation.d.ts
+++ b/packages/maps/map-sdk-augmentation.d.ts
@@ -1,0 +1,28 @@
+/**
+ * 第三方地图 SDK 类型补全
+ *
+ * @types/bmapgl 与 @map-component/tmap-types 未声明、但运行时确实存在且
+ * L7 maps 服务依赖的 BMapGL.Map / TMap.Map 成员。通过 interface 合并增强，
+ * 不引入任何运行时代码。
+ *
+ * 详见: packages/maps/src/{bmap,tmap}/map.ts
+ */
+declare namespace BMapGL {
+  interface Map {
+    // BMapGL.Map 继承 EventEmitter，但 @types/bmapgl 未声明 on/off
+    on(type: string, handler: (...args: any[]) => void): void;
+    off(type: string, handler: (...args: any[]) => void): void;
+    // 与 setMinZoom/setMaxZoom 对应的 getter，运行时存在
+    getMinZoom(): number;
+    getMaxZoom(): number;
+  }
+}
+
+declare namespace TMap {
+  interface Map {
+    // 返回地图容器 DOM，@map-component/tmap-types 未声明
+    getContainer(): HTMLElement;
+    // 按像素偏移平移地图，运行时接受 [x, y] 元组
+    panBy(offset: [number, number]): void;
+  }
+}

--- a/packages/maps/src/bmap/map.ts
+++ b/packages/maps/src/bmap/map.ts
@@ -37,6 +37,8 @@ export default class BMapService extends BaseMap<BMapGL.Map> {
   };
   protected currentStyle: any = 'normal';
 
+  public version: string = BMAP_VERSION;
+
   // Zoom 偏移量，用于对齐不同地图的显示层级
   protected zoomOffset: number = 1.75;
 
@@ -76,7 +78,7 @@ export default class BMapService extends BaseMap<BMapGL.Map> {
     if (this.viewport) {
       this.viewport.syncWithMapCamera(option as any);
       this.updateCoordinateSystemService();
-      this.cameraChangedCallback(this.viewport);
+      this.cameraChangedCallback?.(this.viewport);
     }
   };
 

--- a/packages/maps/src/tmap/map.ts
+++ b/packages/maps/src/tmap/map.ts
@@ -62,7 +62,7 @@ export default class TMapService extends BaseMap<TMap.Map> {
     if (this.viewport) {
       this.viewport.syncWithMapCamera(option as any);
       this.updateCoordinateSystemService();
-      this.cameraChangedCallback(this.viewport);
+      this.cameraChangedCallback?.(this.viewport);
     }
   };
 


### PR DESCRIPTION
## 背景

为 \`@antv/l7-source\` 渐进式重构发 beta（PR #2882 已合并）时，全量 \`pnpm build\` 在 \`@antv/l7-maps\` 的 father declaration 生成阶段中断（exit 1），阻塞 fixed group \`["@antv/l7","@antv/l7-*"]\` 整体发布。

根因：PR #2878 将 bmap/tmap 迁移到 BaseMap 后，第三方 SDK 类型缺失「运行时存在但 \`.d.ts\` 未声明」的成员：

- \`@types/bmapgl\` 的 \`BMapGL.Map\` 未声明 \`on\` / \`off\` / \`getMinZoom\` / \`getMaxZoom\`
- \`@map-component/tmap-types\` 的 \`TMap.Map\` 未声明 \`getContainer\` / \`panBy\`（连带 \`addEventListener\` 回调 \`e\` 隐式 any）

共 18 处 TS 错误（bmap 7 + tmap 11），与 source 重构无关，是 #2878 的既存遗留。

## 修法（补类型声明，非 \`as any\`）

- **新增** \`packages/maps/map-sdk-augmentation.d.ts\`（ambient，与现有 \`style.d.ts\` 同级，tsconfig 默认 include 覆盖）：通过 namespace 接口合并为 \`BMapGL.Map\` 补 \`on/off/getMinZoom/getMaxZoom\`，为 \`TMap.Map\` 补 \`getContainer()/panBy([x,y])\`。无运行时代码，纯声明增强。
- \`bmap/map.ts\`：补 \`public version: string = BMAP_VERSION\` 声明（对齐 \`maplibre/map.ts\`、\`map/map.ts\` 惯例；此前只赋值未声明）。
- \`bmap/map.ts\` / \`tmap/map.ts\`：\`handleCameraChanged\` 中 \`this.cameraChangedCallback(...)\` 改 \`?.\` 可选调用，与 \`BaseMap.updateView\` 一致（\`cameraChangedCallback\` 为可选属性）。

## 验证

- \`pnpm --filter @antv/l7-maps build\`：0 error，48 files transformed
- \`pnpm build\`（全量）：通过，fixed group 解除阻塞
- \`pnpm --filter @antv/l7-maps lint\`：0 error（1 个 tmap/maploader.ts 既存无关 warning）
- 无运行时行为变更（纯类型补全 + 一处可选调用守卫）

## 改动文件

- \`packages/maps/map-sdk-augmentation.d.ts\`（新增）
- \`packages/maps/src/bmap/map.ts\`
- \`packages/maps/src/tmap/map.ts\`
- \`.changeset/fix-maps-bmap-tmap-types.md\`（\`@antv/l7-maps\`: patch）

合并后恢复 source beta 发布流程（beta 本地准备状态已暂存保留）。